### PR TITLE
Adding missing ' in the docs

### DIFF
--- a/src/loader/filetypes/TextFile.js
+++ b/src/loader/filetypes/TextFile.js
@@ -25,7 +25,7 @@ var IsPlainObject = require('../../utils/object/IsPlainObject');
  * A single Text File suitable for loading by the Loader.
  *
  * These are created when you use the Phaser.Loader.LoaderPlugin#text method and are not typically created directly.
- * 
+ *
  * For documentation about what all the arguments and configuration options mean please see Phaser.Loader.LoaderPlugin#text.
  *
  * @class TextFile
@@ -94,11 +94,11 @@ var TextFile = new Class({
  * Adds a Text file, or array of Text files, to the current load queue.
  *
  * You can call this method from within your Scene's `preload`, along with any other files you wish to load:
- * 
+ *
  * ```javascript
  * function preload ()
  * {
- *     this.load.text('story', files/IntroStory.txt');
+ *     this.load.text('story', 'files/IntroStory.txt');
  * }
  * ```
  *
@@ -109,14 +109,14 @@ var TextFile = new Class({
  * The typical flow for a Phaser Scene is that you load assets in the Scene's `preload` method and then when the
  * Scene's `create` method is called you are guaranteed that all of those assets are ready for use and have been
  * loaded.
- * 
+ *
  * The key must be a unique String. It is used to add the file to the global Text Cache upon a successful load.
  * The key should be unique both in terms of files being loaded and files already present in the Text Cache.
  * Loading a file using a key that is already taken will result in a warning. If you wish to replace an existing file
  * then remove it from the Text Cache first, before loading a new one.
  *
  * Instead of passing arguments you can pass a configuration object, such as:
- * 
+ *
  * ```javascript
  * this.load.text({
  *     key: 'story',
@@ -127,7 +127,7 @@ var TextFile = new Class({
  * See the documentation for `Phaser.Loader.FileTypes.TextFileConfig` for more details.
  *
  * Once the file has finished loading you can access it from its Cache using its key:
- * 
+ *
  * ```javascript
  * this.load.text('story', 'files/IntroStory.txt');
  * // and later in your game ...

--- a/src/loader/filetypes/TilemapCSVFile.js
+++ b/src/loader/filetypes/TilemapCSVFile.js
@@ -26,7 +26,7 @@ var TILEMAP_FORMATS = require('../../tilemaps/Formats');
  * A single Tilemap CSV File suitable for loading by the Loader.
  *
  * These are created when you use the Phaser.Loader.LoaderPlugin#tilemapCSV method and are not typically created directly.
- * 
+ *
  * For documentation about what all the arguments and configuration options mean please see Phaser.Loader.LoaderPlugin#tilemapCSV.
  *
  * @class TilemapCSVFile
@@ -112,11 +112,11 @@ var TilemapCSVFile = new Class({
  * Adds a CSV Tilemap file, or array of CSV files, to the current load queue.
  *
  * You can call this method from within your Scene's `preload`, along with any other files you wish to load:
- * 
+ *
  * ```javascript
  * function preload ()
  * {
- *     this.load.tilemapCSV('level1', maps/Level1.csv');
+ *     this.load.tilemapCSV('level1', 'maps/Level1.csv');
  * }
  * ```
  *
@@ -129,14 +129,14 @@ var TilemapCSVFile = new Class({
  * The typical flow for a Phaser Scene is that you load assets in the Scene's `preload` method and then when the
  * Scene's `create` method is called you are guaranteed that all of those assets are ready for use and have been
  * loaded.
- * 
+ *
  * The key must be a unique String. It is used to add the file to the global Tilemap Cache upon a successful load.
  * The key should be unique both in terms of files being loaded and files already present in the Tilemap Cache.
  * Loading a file using a key that is already taken will result in a warning. If you wish to replace an existing file
  * then remove it from the Text Cache first, before loading a new one.
  *
  * Instead of passing arguments you can pass a configuration object, such as:
- * 
+ *
  * ```javascript
  * this.load.tilemapCSV({
  *     key: 'level1',
@@ -147,7 +147,7 @@ var TilemapCSVFile = new Class({
  * See the documentation for `Phaser.Loader.FileTypes.TilemapCSVFileConfig` for more details.
  *
  * Once the file has finished loading you can access it from its Cache using its key:
- * 
+ *
  * ```javascript
  * this.load.tilemapCSV('level1', 'maps/Level1.csv');
  * // and later in your game ...

--- a/src/loader/filetypes/TilemapImpactFile.js
+++ b/src/loader/filetypes/TilemapImpactFile.js
@@ -23,7 +23,7 @@ var TILEMAP_FORMATS = require('../../tilemaps/Formats');
  * A single Impact.js Tilemap JSON File suitable for loading by the Loader.
  *
  * These are created when you use the Phaser.Loader.LoaderPlugin#tilemapImpact method and are not typically created directly.
- * 
+ *
  * For documentation about what all the arguments and configuration options mean please see Phaser.Loader.LoaderPlugin#tilemapImpact.
  *
  * @class TilemapImpactFile
@@ -73,11 +73,11 @@ var TilemapImpactFile = new Class({
  * Adds an Impact.js Tilemap file, or array of map files, to the current load queue.
  *
  * You can call this method from within your Scene's `preload`, along with any other files you wish to load:
- * 
+ *
  * ```javascript
  * function preload ()
  * {
- *     this.load.tilemapImpact('level1', maps/Level1.json');
+ *     this.load.tilemapImpact('level1', 'maps/Level1.json');
  * }
  * ```
  *
@@ -90,14 +90,14 @@ var TilemapImpactFile = new Class({
  * The typical flow for a Phaser Scene is that you load assets in the Scene's `preload` method and then when the
  * Scene's `create` method is called you are guaranteed that all of those assets are ready for use and have been
  * loaded.
- * 
+ *
  * The key must be a unique String. It is used to add the file to the global Tilemap Cache upon a successful load.
  * The key should be unique both in terms of files being loaded and files already present in the Tilemap Cache.
  * Loading a file using a key that is already taken will result in a warning. If you wish to replace an existing file
  * then remove it from the Text Cache first, before loading a new one.
  *
  * Instead of passing arguments you can pass a configuration object, such as:
- * 
+ *
  * ```javascript
  * this.load.tilemapImpact({
  *     key: 'level1',
@@ -108,7 +108,7 @@ var TilemapImpactFile = new Class({
  * See the documentation for `Phaser.Loader.FileTypes.TilemapImpactFileConfig` for more details.
  *
  * Once the file has finished loading you can access it from its Cache using its key:
- * 
+ *
  * ```javascript
  * this.load.tilemapImpact('level1', 'maps/Level1.json');
  * // and later in your game ...

--- a/src/loader/filetypes/TilemapJSONFile.js
+++ b/src/loader/filetypes/TilemapJSONFile.js
@@ -23,7 +23,7 @@ var TILEMAP_FORMATS = require('../../tilemaps/Formats');
  * A single Tiled Tilemap JSON File suitable for loading by the Loader.
  *
  * These are created when you use the Phaser.Loader.LoaderPlugin#tilemapTiledJSON method and are not typically created directly.
- * 
+ *
  * For documentation about what all the arguments and configuration options mean please see Phaser.Loader.LoaderPlugin#tilemapTiledJSON.
  *
  * @class TilemapJSONFile
@@ -73,11 +73,11 @@ var TilemapJSONFile = new Class({
  * Adds a Tiled JSON Tilemap file, or array of map files, to the current load queue.
  *
  * You can call this method from within your Scene's `preload`, along with any other files you wish to load:
- * 
+ *
  * ```javascript
  * function preload ()
  * {
- *     this.load.tilemapTiledJSON('level1', maps/Level1.json');
+ *     this.load.tilemapTiledJSON('level1', 'maps/Level1.json');
  * }
  * ```
  *
@@ -90,14 +90,14 @@ var TilemapJSONFile = new Class({
  * The typical flow for a Phaser Scene is that you load assets in the Scene's `preload` method and then when the
  * Scene's `create` method is called you are guaranteed that all of those assets are ready for use and have been
  * loaded.
- * 
+ *
  * The key must be a unique String. It is used to add the file to the global Tilemap Cache upon a successful load.
  * The key should be unique both in terms of files being loaded and files already present in the Tilemap Cache.
  * Loading a file using a key that is already taken will result in a warning. If you wish to replace an existing file
  * then remove it from the Text Cache first, before loading a new one.
  *
  * Instead of passing arguments you can pass a configuration object, such as:
- * 
+ *
  * ```javascript
  * this.load.tilemapTiledJSON({
  *     key: 'level1',
@@ -108,7 +108,7 @@ var TilemapJSONFile = new Class({
  * See the documentation for `Phaser.Loader.FileTypes.TilemapJSONFileConfig` for more details.
  *
  * Once the file has finished loading you can access it from its Cache using its key:
- * 
+ *
  * ```javascript
  * this.load.tilemapTiledJSON('level1', 'maps/Level1.json');
  * // and later in your game ...


### PR DESCRIPTION
This PR:

* Updates the Documentation
* Fixes a bug (#3873)

Describe the changes below:
Just added ' in the files
