### PR TITLE
On mobile, have pointerup and pointerout get triggered together.

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -1461,6 +1461,9 @@ var InputPlugin = new Class({
                 continue;
             }
 
+            // If pointerup is triggered, we have no need for pointerout.
+            this.this._over[pointer.id] = [];
+
             gameObject.emit(Events.GAMEOBJECT_POINTER_UP, pointer, gameObject.input.localX, gameObject.input.localY, _eventContainer);
 
             if (_eventData.cancelled)
@@ -1489,6 +1492,8 @@ var InputPlugin = new Class({
             {
                 this.emit(Events.POINTER_UP_OUTSIDE, pointer);
             }
+
+            this.this._over[pointer.id] = [];
         }
 
         return currentlyOver.length;

--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -1461,10 +1461,15 @@ var InputPlugin = new Class({
                 continue;
             }
 
-            // If pointerup is triggered, we have no need for pointerout.
-            this._over[pointer.id] = [];
-
             gameObject.emit(Events.GAMEOBJECT_POINTER_UP, pointer, gameObject.input.localX, gameObject.input.localY, _eventContainer);
+
+            // Clear over and emit 'pointerout' on touch.
+            if (pointer.wasTouch)
+            {
+                this._over[pointer.id] = [];
+
+                gameObject.emit(Events.GAMEOBJECT_POINTER_OUT, pointer, gameObject.input.localX, gameObject.input.localY, _eventContainer);
+            }
 
             if (_eventData.cancelled)
             {

--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -1462,7 +1462,7 @@ var InputPlugin = new Class({
             }
 
             // If pointerup is triggered, we have no need for pointerout.
-            this.this._over[pointer.id] = [];
+            this._over[pointer.id] = [];
 
             gameObject.emit(Events.GAMEOBJECT_POINTER_UP, pointer, gameObject.input.localX, gameObject.input.localY, _eventContainer);
 
@@ -1492,8 +1492,6 @@ var InputPlugin = new Class({
             {
                 this.emit(Events.POINTER_UP_OUTSIDE, pointer);
             }
-
-            this.this._over[pointer.id] = [];
         }
 
         return currentlyOver.length;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

In 3.16.1 if you trigger the pointerup event and then move to another interactive object, the past object's pointerover event gets triggered. This clears that and stops that from happening by stopping the pointerover event from being triggered if the pointerup event has been.

