### PR TITLE
Adds support for multiple custom Loader headers

### DIFF
--- a/src/loader/XHRLoader.js
+++ b/src/loader/XHRLoader.js
@@ -30,6 +30,14 @@ var XHRLoader = function (file, globalXHRSettings)
     xhr.responseType = file.xhrSettings.responseType;
     xhr.timeout = config.timeout;
 
+    if (config.headers)
+    {
+        for (var key in config.headers)
+        {
+            xhr.setRequestHeader(key, config.headers[key]);
+        }
+    }
+
     if (config.header && config.headerValue)
     {
         xhr.setRequestHeader(config.header, config.headerValue);

--- a/src/loader/XHRSettings.js
+++ b/src/loader/XHRSettings.js
@@ -45,6 +45,7 @@ var XHRSettings = function (responseType, async, user, password, timeout)
         timeout: timeout,
 
         //  setRequestHeader
+        headers: undefined,
         header: undefined,
         headerValue: undefined,
         requestedWith: false,

--- a/src/loader/typedefs/XHRSettingsObject.js
+++ b/src/loader/typedefs/XHRSettingsObject.js
@@ -7,6 +7,7 @@
  * @property {string} [user=''] - Optional username for the XHR request.
  * @property {string} [password=''] - Optional password for the XHR request.
  * @property {integer} [timeout=0] - Optional XHR timeout value.
+ * @property {(object|undefined)} [headers] - This value is used to populate the XHR `setRequestHeader` and is undefined by default.
  * @property {(string|undefined)} [header] - This value is used to populate the XHR `setRequestHeader` and is undefined by default.
  * @property {(string|undefined)} [headerValue] - This value is used to populate the XHR `setRequestHeader` and is undefined by default.
  * @property {(string|undefined)} [requestedWith] - This value is used to populate the XHR `setRequestHeader` and is undefined by default.


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Previously, it was only possible to pass a single custom header to a Loader through `header` and `headerValue`. This adds the ability to pass multiple headers via a new `headers` property:

```js
this.load.image('sprite', 'assets/sprite.png', {
    headers: {
        Authorization: 'Bearer t0k3n',
    },
});
```
References my adventures in #4616 

