### PR TITLE
Don't fire extra events during event emitting

### DIFF
--- a/src/events/Emit.ts
+++ b/src/events/Emit.ts
@@ -9,6 +9,8 @@ export function Emit (emitter: IEventEmitter, event: string, ...args: unknown[])
 
     const listeners = emitter.events.get(event);
 
+    let counter = listeners.size;
+
     for (const ee of listeners)
     {
         ee.callback.apply(ee.context, args);
@@ -16,6 +18,13 @@ export function Emit (emitter: IEventEmitter, event: string, ...args: unknown[])
         if (ee.once)
         {
             listeners.delete(ee);
+        }
+
+        counter--;
+        
+        if (counter === 0) 
+        {
+            break;
         }
     }
 


### PR DESCRIPTION
This PR try to fix issue #10 

First save amount of requested events into a counter. Exit for-loop when counter is 0.
Or use `Array.From(listeners)` to clone references into a new array.