### PR TITLE
Update GetTriangleCircumCircle.ts

### DIFF
--- a/src/geom/triangle/GetTriangleCircumCircle.ts
+++ b/src/geom/triangle/GetTriangleCircumCircle.ts
@@ -4,7 +4,7 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-import { Circle } from '../Circle/Circle';
+import { Circle } from '../circle/Circle';
 import { ITriangle } from './ITriangle';
 
 /**


### PR DESCRIPTION
Fix problem: WARNING in ./node_modules/@phaserjs/phaser/geom/circle/Circle.js
There are multiple modules with names that only differ in casing.
Updated casing of import folder to fix warning