### PR TITLE
Fix #5828, improve GameObject#disableInteractive() and InputPlugin#disable()

### DIFF
--- a/src/gameobjects/GameObject.js
+++ b/src/gameobjects/GameObject.js
@@ -504,10 +504,7 @@ var GameObject = new Class({
      */
     disableInteractive: function ()
     {
-        if (this.input)
-        {
-            this.input.enabled = false;
-        }
+        this.scene.sys.input.disable(this);
 
         return this;
     },

--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -838,7 +838,43 @@ var InputPlugin = new Class({
      */
     disable: function (gameObject)
     {
-        gameObject.input.enabled = false;
+        var input = gameObject.input;
+
+        if (!input)
+        {
+            return this;
+        }
+
+        input.enabled = false;
+
+        // Clear from _temp, _drag and _over
+        var index = this._temp.indexOf(gameObject);
+
+        if (index > -1)
+        {
+            this._temp.splice(index, 1);
+        }
+
+        for (var i = 0; i < 10; i++)
+        {
+            index = this._drag[i].indexOf(gameObject);
+
+            if (index > -1)
+            {
+                this._drag[i].splice(index, 1);
+            }
+
+            index = this._over[i].indexOf(gameObject);
+
+            if (index > -1)
+            {
+                this._over[i].splice(index, 1);
+
+                this.manager.resetCursor(input);
+            }
+        }
+
+        return this;
     },
 
     /**

--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -846,6 +846,7 @@ var InputPlugin = new Class({
         }
 
         input.enabled = false;
+        input.dragState = 0;
 
         // Clear from _temp, _drag and _over
         var index = this._temp.indexOf(gameObject);


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

Changed the  `GameObject.disableInteractive()` method behavior to be more similar to the `GameObject.removeInteractive()`.
Now, when `GameObject.disableInteractive()` or `InputPlugin.disable(gameObject)` is called, `gameObject` is being immediately removed from the sensitive temporary arrays involved in event processing.
Another possible solution is to revise the internal logic of `InputPlugin` class event processing procedures, changing `if (input) { /* FIRE EVENT */ }` checks to `if (input && input.enabled)`.

_**Everyone can test this PR in the updated [CodeSandbox](https://svk2z.csb.app/)**_

Resolves #5828
