### PR TITLE
Allow for object based scene definitions

### DIFF
--- a/src/scenes/IScene.ts
+++ b/src/scenes/IScene.ts
@@ -1,11 +1,14 @@
 import { Game } from '../Game';
 import { IEventInstance } from '../events/IEventInstance';
 
-export interface IScene
-{
+export type IScene = {
     key?: string;
     game: Game;
     events: Map<string, Set<IEventInstance>>;
+} & ISceneProps;
+
+export type ISceneProps = {
+    create? (): void;
     update? (delta: number, time: number): void;
     shutdown? (): void;
     destroy? (): void;

--- a/src/scenes/ISceneConstructor.ts
+++ b/src/scenes/ISceneConstructor.ts
@@ -1,7 +1,7 @@
-import { IScene } from './IScene';
+import { IScene, ISceneProps } from './IScene';
 import { ISceneConfig } from './ISceneConfig';
 
-export interface ISceneConstructor
+export type ISceneConstructor =
 {
     new (config?: string | ISceneConfig): IScene;
-}
+} | ISceneProps;

--- a/src/scenes/SceneManager.ts
+++ b/src/scenes/SceneManager.ts
@@ -9,6 +9,7 @@ import { ResetRenderStats } from './ResetRenderStats';
 import { SceneManagerInstance } from './SceneManagerInstance';
 import { WorldList } from '../world/WorldList';
 import { addEntity } from 'bitecs';
+import { Scene } from './Scene';
 
 export class SceneManager
 {
@@ -39,7 +40,35 @@ export class SceneManager
 
         if (scenes)
         {
-            scenes.forEach(scene => new scene());
+            scenes.forEach(sceneCtor =>
+            {
+                let s: IScene;
+                
+                if (typeof sceneCtor === "function")
+                {
+                    if (sceneCtor.prototype.hasOwnProperty("constructor"))
+                    {
+                        s = new sceneCtor();
+                    }
+                    else
+                    {
+                        throw new Error("ISceneConstructor must either be a class extending Scene or an object implementing ISceneProps")
+                    }
+                }
+                else
+                {
+                    s = new Scene();
+                    if (sceneCtor.create) s.create = sceneCtor.create.bind(s);
+                    if (sceneCtor.destroy) s.destroy = sceneCtor.destroy.bind(s);
+                    if (sceneCtor.update) s.update = sceneCtor.update.bind(s);
+                    if (sceneCtor.shutdown) s.shutdown = sceneCtor.shutdown.bind(s);
+                }
+
+                if (s.create)
+                {
+                    s.create();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
I think it would be awesome if Phaser 4 allowed for simple object literal scene syntax like previous versions had.  Something like:

```ts
const scene = {
    key: "main",
    create() {
        const world = new StaticWorld(this);
        On(world, WorldPostRenderEvent, (renderPass: IRenderPass) => {
        });
    }
}

CreateGame(
    WebGL(),
    Parent('gameParent'),
    Scenes(scene)
)
```
[Full Example](https://github.com/Mattykins/dev/blob/main/examples/src/direct%20mode/object%20scene.ts#L11-L27)

This is somewhat achievable through the `const game = await CreateGame(...); On(game ...` syntax but a lot of the constructors like `StaticWorld` need an `IScene`. 

Also I think this option is the most approachable, especially for educational purposes where someone might not yet know what a class is. I've ran game jams with people that had no prior game-dev experience and often limited coding knowledge, its less code to get someone up and running. I loved Phaser 3 for this.

I also think it increases interoperability with the broader javascript ecosystem. Specific example is in ClojureScript, emitting a defined ES6 class that extends a base class is not trivial. 

Super open to feedback on the approach. One major thing I needed to do was to add a create method to the IScene, I dont know if you have other plans for this sort of thing.