### PR TITLE
Allow objects to destroy other objects when the DisplayList is shutting down

### DIFF
--- a/src/gameobjects/DisplayList.js
+++ b/src/gameobjects/DisplayList.js
@@ -231,14 +231,12 @@ var DisplayList = new Class({
     {
         var list = this.list;
 
-        var i = list.length;
+        var currentObject;
 
-        while (i--)
+        while ((currentObject = list.pop()) !== undefined)
         {
-            list[i].destroy(true);
+            currentObject.destroy(true);
         }
-
-        list.length = 0;
 
         this.events.off(SceneEvents.SHUTDOWN, this.shutdown, this);
     },


### PR DESCRIPTION
This PR fixes a bug (#5520).

Describe the changes below:

This PR fixes `DisplayList.shutdown()` to allow users to destroy other game objects whilst another object is being destroyed without tripping up. Objects are destroyed in reverse order for full compatibility.

While checking to see if `fromScene` is `true` before destroying any objects that could be on the Display List would also fix the issue, doing so is not concise.