### PR TITLE
Warn when there is a multiFile load failure

### DIFF
--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -892,8 +892,8 @@ var LoaderPlugin = new Class({
                 }
                 else
                 {
-                    var srcs = file.multiFile.files.map(function(it) { return it.src }).join(', '));
-                    console.warn("failed to load multiFile into cache: " + srcs;
+                    var srcs = file.multiFile.files.map(function(it) { return it.src; }).join(', ');
+                    console.warn("failed to load multiFile into cache: " + srcs);
                 }
             }
             else

--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -892,7 +892,8 @@ var LoaderPlugin = new Class({
                 }
                 else
                 {
-                    console.warn("failed to load multiFile into cache: " + file.multiFile.files.map(i => i.src).join(', '));
+                    var srcs = file.multiFile.files.map(function(it) { return it.src }).join(', '));
+                    console.warn("failed to load multiFile into cache: " + srcs;
                 }
             }
             else

--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -890,6 +890,10 @@ var LoaderPlugin = new Class({
                     //  If we got here then all files the link file needs are ready to add to the cache
                     file.multiFile.addToCache();
                 }
+                else
+                {
+                    console.warn("failed to load multiFile into cache: " + file.multiFile.files.map(i => i.src).join(', '));
+                }
             }
             else
             {


### PR DESCRIPTION
I spent more than an hour debugging this. The animation wasn't working.
I eventually found that I was loading an invalid URL as an Aseprite texture.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Warn when one file fails to load out of a multiFile. E.g. when a aseprite texture fails to load because of an invalid URL.