### PR TITLE
Add new `Path#getCurveAt()` method

### DIFF
--- a/src/curves/path/Path.js
+++ b/src/curves/path/Path.js
@@ -470,6 +470,35 @@ var Path = new Class({
     },
 
     /**
+     * Returns the Curve that forms the Path at the given normalized location (between 0 and 1).
+     *
+     * @method Phaser.Curves.Path#getCurveAt
+     * @since 3.60.0
+     *
+     * @param {number} t - The normalized location on the Path, between 0 and 1.
+     *
+     * @return {?Phaser.Curves.Curve} The Curve that is part of this Path at a given location.
+     */
+    getCurveAt: function (t)
+    {
+        var d = t * this.getLength();
+        var curveLengths = this.getCurveLengths();
+        var i = 0;
+
+        while (i < curveLengths.length)
+        {
+            if (curveLengths[i] >= d)
+            {
+                return this.curves[i];
+            }
+
+            i++;
+        }
+
+        return null;
+    },
+
+    /**
      * Returns the ending point of the Path.
      *
      * A Path's ending point is equivalent to the ending point of the last Curve in the Path. For an empty Path, the ending point is at the Path's defined {@link #startPoint}.


### PR DESCRIPTION
This PR

* Adds a new feature

Describe the changes below:

This new method allows you to find out exactly which Curve object forms the Path at a given normalized location.
Based on the stripped-down code of the `Path#getPoint()` method.