### PR TITLE
Fix rendering of Tiled object layers on isometric maps

### DIFF
--- a/scripts/copy-to-examples.js
+++ b/scripts/copy-to-examples.js
@@ -58,11 +58,11 @@ if (fs.existsSync(dest))
 
         const options = {
             path: './src',
-            extensions: [ 'js' ]
+            extensions: [ '.js' ]
         };
-
+ 
         sloc(options).then((res) => {
-            console.log('Source files: ' + res.files + '\nLines of code: ' + res.sloc);
+            console.log('Source files: ' + res.sloc.files + '\nLines of code: ' + res.sloc.sloc);
         });
 
     });

--- a/scripts/copy-to-examples.js
+++ b/scripts/copy-to-examples.js
@@ -58,11 +58,11 @@ if (fs.existsSync(dest))
 
         const options = {
             path: './src',
-            extensions: [ '.js' ]
+            extensions: [ 'js' ]
         };
- 
+
         sloc(options).then((res) => {
-            console.log('Source files: ' + res.sloc.files + '\nLines of code: ' + res.sloc.sloc);
+            console.log('Source files: ' + res.files + '\nLines of code: ' + res.sloc);
         });
 
     });

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -831,9 +831,10 @@ var Tilemap = new Class({
 
                 if (this.orientation === ORIENTATION.ISOMETRIC)
                 {
+                    var isometricRatio = this.tileWidth / this.tileHeight;
                     var isometricPosition = {
                         x: sprite.x - sprite.y,
-                        y: (sprite.x + sprite.y) / 2
+                        y: (sprite.x + sprite.y) / isometricRatio
                     };
 
                     sprite.x = isometricPosition.x;

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -832,12 +832,12 @@ var Tilemap = new Class({
                 if (this.orientation === ORIENTATION.ISOMETRIC)
                 {
                     var isometricPosition = {
-                      x: sprite.x - sprite.y,
-                      y: (sprite.x + sprite.y) / 2
-                    }
+                        x: sprite.x - sprite.y,
+                        y: (sprite.x + sprite.y) / 2
+                    };
 
-                    sprite.x = isometricPosition.x
-                    sprite.y = isometricPosition.y
+                    sprite.x = isometricPosition.x;
+                    sprite.y = isometricPosition.y;
                 }
 
                 //  Origin is (0, 1) for tile objects or (0, 0) for other objects in Tiled, so find the offset that matches the Sprites origin.

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -829,6 +829,17 @@ var Tilemap = new Class({
                     sprite.displayHeight = obj.height;
                 }
 
+                if (this.orientation === ORIENTATION.ISOMETRIC)
+                {
+                    var isometricPosition = {
+                      x: sprite.x - sprite.y,
+                      y: (sprite.x + sprite.y) / 2
+                    }
+
+                    sprite.x = isometricPosition.x
+                    sprite.y = isometricPosition.y
+                }
+
                 //  Origin is (0, 1) for tile objects or (0, 0) for other objects in Tiled, so find the offset that matches the Sprites origin.
                 //  Do not offset objects with zero dimensions (e.g. points).
                 var offset = {


### PR DESCRIPTION
This PR:

* Fixes a bug

Describe the changes below:
Objects contained in object layers generated by Tiled use orthogonal positioning even when the map is isometric. In the pictures below, note that `A` has `{x:128, y:128}` and `B` has `{x:256, y:128}` - the `y` is the same, as one would expect in an orthogonal grid (but not in an isometric one).

![image](https://user-images.githubusercontent.com/4733061/135769107-703a3b5a-816f-4ce1-9436-95d0e3233a01.png)
![image](https://user-images.githubusercontent.com/4733061/135769120-5637be46-6efe-495a-a9b2-33155978f944.png)

The current way to position sprites on `createFromObjects` uses that position provided by Tiled and applies an origin offset over it - leading to issues [as described here](https://phaser.discourse.group/t/objects-position-are-wrong-in-isometric-map-created-with-tiled/8771).

This PR converts the sprites' position from cartesian to isometric before applying the offset, positioning elements over the grid as expected.
