### PR TITLE
Add static Lerp method on Vector2

### DIFF
--- a/src/math/LinearXY.js
+++ b/src/math/LinearXY.js
@@ -1,0 +1,30 @@
+/**
+ * @author       Greg McLean <GregDevProjects>
+ * @copyright    2021 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+/**
+ * Interpolates two given Vectors and returns a new Vector between them.
+ *
+ * Does not modify either of the passed Vectors.
+ *
+ * @function Phaser.Math.LinearXY
+ * @since 3.6.0
+ *
+ * @param {Phaser.Math.Vector2} vector1 - Starting vector
+ * @param {Phaser.Math.Vector2} vector2 - Ending vector
+ * @param {number} [t=0] - The percentage between vector1 and vector2 to return, represented as a number between 0 and 1.
+ *
+ * @return {Phaser.Math.Vector2} The step t% of the way between vector1 and vector2.
+ */
+var LinearXY = function (vector1, vector2, t)
+{
+    if (t === undefined)
+    {
+        t = 0;
+    }
+    return vector1.clone().lerp(vector2, t);
+};
+
+module.exports = LinearXY;

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -767,23 +767,4 @@ Vector2.DOWN = new Vector2(0, 1);
  */
 Vector2.ONE = new Vector2(1, 1);
 
-/**
- * Interpolates two given Vectors and returns a new Vector.
- *
- * Does not modify either of the passed Vectors.
- * 
- * @method Phaser.Math.Vector2
- * @since 3.6.0
- *
- * @param {Phaser.Math.Vector2} vector1 - Starting vector
- * @param {Phaser.Math.Vector2} vector2 - Ending vector
- * @param {number} [t=0] - The interpolation percentage, between 0 and 1.
- * @return {Phaser.Math.Vector2} Value of the interpolation
- */
-Vector2.Lerp = function (vector1, vector2, t)
-{
-    if (t === undefined) { t = 0; }
-    return vector1.clone().lerp(vector2, t);
-};
-
 module.exports = Vector2;

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -767,4 +767,23 @@ Vector2.DOWN = new Vector2(0, 1);
  */
 Vector2.ONE = new Vector2(1, 1);
 
+/**
+ * Interpolates two given Vectors and returns a new Vector.
+ *
+ * Does not modify either of the passed Vectors.
+ * 
+ * @method Phaser.Math.Vector2
+ * @since 3.6.0
+ *
+ * @param {Phaser.Math.Vector2} vector1 - Starting vector
+ * @param {Phaser.Math.Vector2} vector2 - Ending vector
+ * @param {number} [t=0] - The interpolation percentage, between 0 and 1.
+ * @return {Phaser.Math.Vector2} Value of the interpolation
+ */
+Vector2.Lerp = function (vector1, vector2, t)
+{
+    if (t === undefined) { t = 0; }
+    return vector1.clone().lerp(vector2, t);
+};
+
 module.exports = Vector2;

--- a/src/math/index.js
+++ b/src/math/index.js
@@ -43,6 +43,7 @@ var PhaserMath = {
     IsEven: require('./IsEven'),
     IsEvenStrict: require('./IsEvenStrict'),
     Linear: require('./Linear'),
+    LinearXY: require('./LinearXY'),
     MaxAdd: require('./MaxAdd'),
     Median: require('./Median'),
     MinSub: require('./MinSub'),


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Adds a static method to the Vector2 class so that two vectors can be lerped (if that's a word 😛 ) without modifying the original Vectors. 

Resolves #5684.

