### PR TITLE
Fix PathFollower end point when given `to`

### DIFF
--- a/src/gameobjects/components/PathFollower.js
+++ b/src/gameobjects/components/PathFollower.js
@@ -367,7 +367,7 @@ var PathFollower = {
 
             if (tweenData.state === TWEEN_CONST.COMPLETE)
             {
-                this.path.getPoint(1, pathVector);
+                this.path.getPoint(tweenData.end, pathVector);
 
                 pathDelta.add(pathVector);
                 pathVector.add(this.pathOffset);


### PR DESCRIPTION
This PR 

* Fixes a bug

If you started a path follower with a `to` value, the follower would complete at the end of the path instead of the `to` value.

