### PR TITLE
Fix missing `QuadraticBezier` curves in `Path.fromJSON()` results

### DIFF
--- a/src/curves/QuadraticBezierCurve.js
+++ b/src/curves/QuadraticBezierCurve.js
@@ -31,7 +31,7 @@ var QuadraticBezier = new Class({
 
     function QuadraticBezier (p0, p1, p2)
     {
-        Curve.call(this, 'QuadraticBezier');
+        Curve.call(this, 'QuadraticBezierCurve');
 
         if (Array.isArray(p0))
         {


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

It corrects the `type` field of the `QuadraticBezier` curve class.
`Path.fromJSON()` method assumes that the `QuadraticBezier` curve class has a value of "**QuadraticBezierCurve**" in the `type` field, but its not.
https://github.com/photonstorm/phaser/blob/fab217ed9c92792e068ead9b62f863b7baa617c1/src/curves/path/Path.js#L377-L379
