### PR TITLE
Add `snap` to Scale Manager config

### DIFF
--- a/src/core/Config.js
+++ b/src/core/Config.js
@@ -116,6 +116,16 @@ var Config = new Class({
          */
         this.maxHeight = GetValue(config, 'maxHeight', 0);
 
+        /**
+         * @const {number} Phaser.Core.Config#snapWidth - The snap width, in pixels. A value of zero means no snapping.
+         */
+        this.snapWidth = 0;
+
+        /**
+         * @const {number} Phaser.Core.Config#snapHeight - The snap height, in pixels. A value of zero means no snapping.
+         */
+        this.snapHeight = 0;
+
         //  Scale Manager - Anything set in here over-rides anything set above
 
         var scaleConfig = GetValue(config, 'scale', null);
@@ -136,6 +146,8 @@ var Config = new Class({
             this.maxWidth = GetValue(scaleConfig, 'max.width', this.maxWidth);
             this.minHeight = GetValue(scaleConfig, 'min.height', this.minHeight);
             this.maxHeight = GetValue(scaleConfig, 'max.height', this.maxHeight);
+            this.snapWidth = GetValue(scaleConfig, 'snap.width', this.snapWidth);
+            this.snapHeight = GetValue(scaleConfig, 'snap.height', this.snapHeight);
         }
 
         /**

--- a/src/core/typedefs/ScaleConfig.js
+++ b/src/core/typedefs/ScaleConfig.js
@@ -10,6 +10,7 @@
  * @property {Phaser.Scale.ScaleModeType} [mode=Phaser.Scale.ScaleModes.NONE] - The scale mode.
  * @property {WidthHeight} [min] - The minimum width and height the canvas can be scaled down to.
  * @property {WidthHeight} [max] - The maximum width the canvas can be scaled up to.
+ * @property {WidthHeight} [snap] - The snap width and height. When the parent is resized the canvas dimensions will snap down to the nearest multiple of these values. `min` should be set, and `min` and `max` should be multiples of the snap values.
  * @property {boolean} [autoRound=false] - Automatically round the display and style sizes of the canvas. This can help with performance in lower-powered devices.
  * @property {Phaser.Scale.CenterType} [autoCenter=Phaser.Scale.Center.NO_CENTER] - Automatically center the canvas within the parent?
  * @property {number} [resizeInterval=500] - How many ms should elapse before checking if the browser size has changed?

--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -563,6 +563,11 @@ var ScaleManager = new Class({
             this.displaySize.setMax(config.maxWidth * zoom, config.maxHeight * zoom);
         }
 
+        if (config.snapWidth > 0)
+        {
+            this.displaySize.setSnap(config.snapWidth * zoom, config.snapHeight * zoom);
+        }
+
         //  The size used for the canvas style, factoring in the scale mode and parent and zoom value
         //  We just use the w/h here as this is what sets the aspect ratio (which doesn't then change)
         this.displaySize.setSize(width, height);


### PR DESCRIPTION
This PR

* Adds a new feature

Use like

```js
new Phaser.Game({
  scale: {
    mode: Phaser.Scale.FIT,
    width: 800,
    height: 600,
    min: { width: 400, height: 300 },
    snap: { width: 400, height: 300 },
  },
});
```

#5892

