### PR TITLE
fix: The window touchcancel event is not removed

### DIFF
--- a/src/input/touch/TouchManager.js
+++ b/src/input/touch/TouchManager.js
@@ -384,6 +384,7 @@ var TouchManager = new Class({
         {
             window.removeEventListener('touchstart', this.onTouchStartWindow);
             window.removeEventListener('touchend', this.onTouchEndWindow);
+            window.removeEventListener('touchcancel', this.onTouchCancelWindow);
         }
     },
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug
On mobile platforms, frequent create destroy games cause GPU memory leaks