### PR TITLE
fixes a bug in Phaser.Loader.LoaderPlugin#texture

### DIFF
--- a/src/loader/filetypes/CompressedTextureFile.js
+++ b/src/loader/filetypes/CompressedTextureFile.js
@@ -458,11 +458,11 @@ FileTypesManager.register('texture', function (key, url, xhrSettings)
         var entry = {
             format: null,
             type: null,
-            textureURL: null,
-            atlasURL: null,
-            multiAtlasURL: null,
-            multiPath: null,
-            multiBaseURL: null
+            textureURL: undefined,
+            atlasURL: undefined,
+            multiAtlasURL: undefined,
+            multiPath: undefined,
+            multiBaseURL: undefined
         };
 
         if (IsPlainObject(key))
@@ -507,13 +507,16 @@ FileTypesManager.register('texture', function (key, url, xhrSettings)
         }
         else if (entry.format === 'IMG')
         {
+            var multifile;
             if (entry.multiAtlasURL)
             {
-                loader.addFile(new MultiAtlasFile(loader, key, entry.multiAtlasURL, entry.multiPath, entry.multiBaseURL, xhrSettings));
+                multifile = new MultiAtlasFile(this, key, entry.multiAtlasURL, entry.multiPath, entry.multiBaseURL, xhrSettings);
+                loader.addFile(multifile.files);
             }
             else if (entry.atlasURL)
             {
-                loader.addFile(new AtlasJSONFile(loader, key, entry.textureURL, entry.atlasURL, xhrSettings));
+                multifile = new AtlasJSONFile(loader, key, entry.textureURL, entry.atlasURL, xhrSettings);
+                loader.addFile(multifile.files);
             }
             else
             {


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:
Changed "Phaser.Loader.LoaderPlugin#texture" to add MultiAtlasFile and AtlasJSONFile via loader.addFile(multifile.files) like in
"Phaser.Loader.LoaderPlugin#multiatlas" to fix a bug where "Phaser.Loader.LoaderPlugin#keyExists" would give and Uncaught TypeError: "file.hasCacheConflict is not a function" if you loaded a MultiAtlas image. Also made the entry variable use undefined instead of null for some fields as null would not make the file use their default values properly.

Example code to show the bug:
```
class Demo extends Phaser.Scene
{
    constructor ()
    {
        super();
    }

    preload ()
    {
        const path = 'assets/compressed';

        debugger;
        this.load.texture('test', {
            'IMG': { multiAtlasURL: `${path}/multi.json`, multiPath: `${path}` }
        });
    }

    create ()
    {
        this.add.sprite(400, 250, 'test', 'phaser3-logo-x2');
        this.add.sprite(400, 100, 'test', 'astorm-truck');
        this.add.sprite(400, 420, 'test', 'bunny');
    }
}
```
