### PR TITLE
Improve the "Invalid Tilemap Layer" warning

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -594,7 +594,7 @@ var Tilemap = new Class({
 
             if (typeof layerID === 'string')
             {
-                console.warn('Valid tilelayer names:\n\t' + this.getTileLayerNames().join(',\n\t'));
+                console.warn('Valid tilelayer names: %o', this.getTileLayerNames());
             }
 
             return null;


### PR DESCRIPTION
This PR

* Adds a new feature

I changed the _Valid tilelayer names: …_ console warning so it's all on one line (shorter).

