### PR TITLE
Docs: namespace ArcadePhysicsCallback type

### DIFF
--- a/src/physics/arcade/typedefs/ArcadePhysicsCallback.js
+++ b/src/physics/arcade/typedefs/ArcadePhysicsCallback.js
@@ -1,5 +1,5 @@
 /**
- * @callback ArcadePhysicsCallback
+ * @callback Phaser.Types.Physics.Arcade.ArcadePhysicsCallback
  *
  * A callback receiving two Game Objects.
  *


### PR DESCRIPTION
This PR

* Updates the Documentation

Changes `ArcadePhysicsCallback` to `Phaser.Types.Physics.Arcade.ArcadePhysicsCallback`.

