### PR TITLE
Remove GetBounds component from PointLight

### DIFF
--- a/src/gameobjects/pointlight/PointLight.js
+++ b/src/gameobjects/pointlight/PointLight.js
@@ -69,7 +69,6 @@ var PointLight = new Class({
         Components.AlphaSingle,
         Components.BlendMode,
         Components.Depth,
-        Components.GetBounds,
         Components.Mask,
         Components.Pipeline,
         Components.ScrollFactor,


### PR DESCRIPTION
This PR

* Fixes a bug

All of the [GetBounds](https://newdocs.phaser.io/docs/3.55.2/Phaser.GameObjects.Components.GetBounds) methods will fail on PointLight, because it's missing the required properties.

Closes #5934

