### PR TITLE
fix sceneManager moveBelow and moveAbove

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -1458,7 +1458,7 @@ var SceneManager = new Class({
                 this.scenes.splice(indexB, 1);
 
                 //  Add in new location
-                this.scenes.splice(indexA + 1, 0, tempScene);
+                this.scenes.splice(indexA + (indexB > indexA), 0, tempScene);
             }
         }
 
@@ -1508,7 +1508,7 @@ var SceneManager = new Class({
                 else
                 {
                     //  Add in new location
-                    this.scenes.splice(indexA, 0, tempScene);
+                    this.scenes.splice(indexA - (indexB < indexA), 0, tempScene);
                 }
             }
         }


### PR DESCRIPTION
Because the index of A and B is stored before B is remove, with splice, the code need to take into account that the index of A decrement if B was below it

