### PR TITLE
Remove `path` from package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "imports-loader": "^3.1.1",
     "jsdoc": "^3.6.7",
     "node-sloc": "^0.2.1",
+    "path": "^0.12.7",
     "remove-files-webpack-plugin": "^1.5.0",
     "source-map": "^0.7.3",
     "terser-webpack-plugin": "^5.2.5",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "dependencies": {
-    "eventemitter3": "^4.0.7",
-    "path": "^0.12.7"
+    "eventemitter3": "^4.0.7"
   }
 }


### PR DESCRIPTION
This PR
* Fixes a bug

Describe the changes below:
Removing an unnecessary library dependency
* which replaces the native nodejs library 
* was last updated 6 years ago https://www.npmjs.com/package/path
* breaks other libraries in project during build that use require('path')
