### PR TITLE
Bugfix: TimeStep: Continue to use `setTimeout` after waking

### DIFF
--- a/src/core/TimeStep.js
+++ b/src/core/TimeStep.js
@@ -651,7 +651,7 @@ var TimeStep = new Class({
             this.startTime += -this.lastTime + (this.lastTime + window.performance.now());
         }
 
-        this.raf.start(this.step.bind(this), this.useRAF);
+        this.raf.start(this.step.bind(this), this.forceSetTimeOut, this._target);
 
         this.running = true;
 


### PR DESCRIPTION
This PR **fixes a bug** where **waking a slept game reverts to using rAF instead of setTimeout** when provided with a `forceSetTimeout` property in the game config.

The following code snippet demonstrates the issue:

```ts
const game = new Phaser.Game({
  fps: {
    forceSetTimeOut: true,
    target: 15,
  },
  ...
});
// Observe: game runs at 15fps as expected

await waitASecond();
game.loop.sleep();
// Observe: game effectively 'paused' as expected

await waitASecond();
game.loop.wake();
// Observe: game runs at > 15fps, using rAF instead of setTimeout
```

Examining the code, it seems there is a lingering reference to `useRAF` which seems to have been missed in #4179 - note in `TimeStep.js` that only the one instance of `this.raf.start` is changed: https://github.com/photonstorm/phaser/pull/4179/files#diff-bc46d42f3975b430a814e0f67dc311d2709e8c3223d521a77e7795df96637762R438


Please let me know if I can provide any further information! Thank you!
