### PR TITLE
destroy game objects during shutdown safely #5520

### DIFF
--- a/src/gameobjects/DisplayList.js
+++ b/src/gameobjects/DisplayList.js
@@ -231,14 +231,10 @@ var DisplayList = new Class({
     {
         var list = this.list;
 
-        var i = list.length;
-
-        while (i--)
+        while (list.length)
         {
-            list[i].destroy(true);
+            list[0].destroy(true);
         }
-
-        list.length = 0;
 
         this.events.off(SceneEvents.SHUTDOWN, this.shutdown, this);
     },


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR

* Fixes a bug #5520

Describe the changes below:
- Since `destroy` removes the game object from the `list`, enumerating through the list is not safe. Instead, we can simply destroy all the game objects until the list is empty.