### PR TITLE
Revert "Skip intersects check by argument"

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1346,14 +1346,12 @@ var World = new Class({
      * @param {ArcadePhysicsCallback} [processCallback] - The process callback.
      * @param {*} [callbackContext] - The context in which to invoke the callback.
      * @param {boolean} [overlapOnly] - If this a collide or overlap check?
-     * @param {boolean} [intersects] - Assert that the bodies intersect and should not be tested before separation.
      *
      * @return {boolean} True if separation occurred, otherwise false.
      */
-    separate: function (body1, body2, processCallback, callbackContext, overlapOnly, intersects)
+    separate: function (body1, body2, processCallback, callbackContext, overlapOnly)
     {
         if (
-            !intersects &&
             !body1.enable ||
             !body2.enable ||
             body1.checkCollision.none ||
@@ -2002,7 +2000,7 @@ var World = new Class({
                     continue;
                 }
 
-                if (this.separate(bodyA, bodyB, processCallback, callbackContext, overlapOnly, true))
+                if (this.separate(bodyA, bodyB, processCallback, callbackContext, overlapOnly))
                 {
                     if (collideCallback)
                     {


### PR DESCRIPTION
This PR

* Fixes a bug

d80e4f5 was wrong — the `intersects()` check should not be skipped — but because it includes a logical mistake it didn't cause any problems. Nevertheless I want to get rid of it.

So this removes the optional `intersects` argument in `Phaser.Physics.Arcade.World#separate()`. Phaser no longer uses it and it never worked so this isn't really a breaking change.



