### PR TITLE
Add setTint() method in Mesh GameObject

### DIFF
--- a/src/gameobjects/mesh/Mesh.js
+++ b/src/gameobjects/mesh/Mesh.js
@@ -1064,8 +1064,78 @@ var Mesh = new Class({
 
         this.debugCallback = null;
         this.debugGraphic = null;
-    }
+    },
 
+    /**
+     * Clears all tint values associated with this Game Object.
+     *
+     * Immediately sets the color values back to 0xffffff and the tint type to 'additive',
+     * which results in no visible change to the texture.
+     *
+     * @method Phaser.GameObjects.Mesh#clearTint
+     * @webglOnly
+     * @since 3.60.0
+     *
+     * @return {this} This Game Object instance.
+     */
+    clearTint: function ()
+    {
+        this.setTint(0xffffff);
+ 
+        return this;
+    },
+
+    /**
+     * Sets an additive tint on all vertices of this Mesh Game Object.
+     *
+     * The tint works by taking the pixel color values from the Game Objects texture, and then
+     * multiplying it by the color value of the tint.
+     *
+     * To modify the tint color once set, either call this method again with new values or use the
+     * `tint` property to set all colors at once.
+     *
+     * To remove a tint call `clearTint`.
+     *
+     * To swap this from being an additive tint to a fill based tint set the property `tintFill` to `true`.
+     *
+     * @method Phaser.GameObjects.Mesh#setTint
+     * @webglOnly
+     * @since 3.60.0
+     *
+     * @param {number} [topLeft=0xffffff] - The tint being applied to the top-left of the Game Object. If no other values are given this value is applied evenly, tinting the whole Game Object.
+     *
+     * @return {this} This Game Object instance.
+     */
+    setTint: function (tint)
+    {
+        if (tint === undefined) { tint = 0xffffff; }
+  
+        var vertices = this.vertices;
+    
+        for (var i = 0; i < vertices.length; i++)
+        {
+            vertices[i].color = tint;
+        }
+  
+        return this;
+    },
+ 
+    /**
+     * The tint value being applied to the whole of the Game Object.
+     * This property is a setter-only.
+     *
+     * @method Phaser.GameObjects.Mesh#tint
+     * @type {number}
+     * @webglOnly
+     * @since 3.60.0
+     */
+    tint: {
+
+        set: function (value)
+        {
+            this.setTint(value);
+        }
+    }
 });
 
 module.exports = Mesh;


### PR DESCRIPTION
This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Add `setTint()` method, `tint` setter in Mesh GameObject.
Which will set `color` property of all vertices of this Mesh Game Object.