### PR TITLE
Tag as optional the `anims.chain()` argument.

### DIFF
--- a/src/animations/AnimationState.js
+++ b/src/animations/AnimationState.js
@@ -472,7 +472,7 @@ var AnimationState = new Class({
      * @method Phaser.Animations.AnimationState#chain
      * @since 3.16.0
      *
-     * @param {(string|Phaser.Animations.Animation|Phaser.Types.Animations.PlayAnimationConfig|string[]|Phaser.Animations.Animation[]|Phaser.Types.Animations.PlayAnimationConfig[])} key - The string-based key of the animation to play, or an Animation instance, or a `PlayAnimationConfig` object, or an array of them.
+     * @param {(string|Phaser.Animations.Animation|Phaser.Types.Animations.PlayAnimationConfig|string[]|Phaser.Animations.Animation[]|Phaser.Types.Animations.PlayAnimationConfig[])} [key] - The string-based key of the animation to play, or an Animation instance, or a `PlayAnimationConfig` object, or an array of them.
      *
      * @return {Phaser.GameObjects.GameObject} The Game Object that owns this Animation Component.
      */


### PR DESCRIPTION
The `chain()` method accepts no argument to reset the chain of animations.

This PR (delete as applicable)

* Updates the Documentation
* Adds a new feature
* Fixes a bug

Describe the changes below:

Updates the JSDoc of the `AnimationState.chain(key)` method. It sets the arguments as optional.
