### PR TITLE
Fix `pointToContainer` issue with `output` parameter

### DIFF
--- a/src/gameobjects/container/Container.js
+++ b/src/gameobjects/container/Container.js
@@ -498,7 +498,8 @@ var Container = new Class({
         }
         else
         {
-            output = new Vector2(source.x, source.y);
+            output.x = source.x;
+            output.y = source.y;
         }
 
         var tempMatrix = this.tempTransformMatrix;


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:
Provided `output` parameter was ignored when the container didn't have a parent container (was attached directly to the scene)
