### PR TITLE
Fix: `convertTilemapLayer` creating composite bodies unintentionally

### DIFF
--- a/src/physics/matter-js/MatterTileBody.js
+++ b/src/physics/matter-js/MatterTileBody.js
@@ -235,8 +235,9 @@ var MatterTileBody = new Class({
         }
         else if (parts.length > 1)
         {
-            options.parts = parts;
-            this.setBody(Body.create(options), options.addToWorld);
+            var tempOptions = JSON.parse(JSON.stringify(options));
+            tempOptions.parts = parts;
+            this.setBody(Body.create(tempOptions), options.addToWorld);
         }
 
         return this;


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

There is an edge case that could cause a crash when using `convertTilemapLayers` to create Matter.js bodies from a Tilemap. If any tiles had multiple colliders _and_ you were providing some body creation options, the `parts` property in the options would be modified and then concatenated with any bodies created after it. This would mean that some tiles would be combined when they shouldn't be, and on large maps would eventually hang once the convex hull got too big/complex.

This PR just clones the `options` object before modifying it. You may already have a favoured way of doing this.
