### PR TITLE
Fix to SafeRange to allow more valid ranges

### DIFF
--- a/src/utils/array/SafeRange.js
+++ b/src/utils/array/SafeRange.js
@@ -24,8 +24,7 @@ var SafeRange = function (array, startIndex, endIndex, throwError)
     if (startIndex < 0 ||
         startIndex > len ||
         startIndex >= endIndex ||
-        endIndex > len ||
-        startIndex + endIndex > len)
+        endIndex > len)
     {
         if (throwError)
         {


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:

Closes #5979

The condition `startIndex + endIndex > len`, in SafeRange.js is not necessary, and it restricts valid ranges.
```javascript
/* src/utils/arrays/SafeRange.js */
var SafeRange = function (array, startIndex, endIndex, throwError)
{
    var len = array.length;

    if (startIndex < 0 ||
        startIndex > len ||
        startIndex >= endIndex ||
        endIndex > len ||
        startIndex + endIndex > len)
    {
```
The fix will allow the following ranges to be considered valid:
```
[n, Array.length), n = {1, ..., Array.length-1}, Array.length > 1
[n, m), n = {1, ..., Array.length - 1}, m = {n+1, ..., Array.length}, Array.length > 1
```

The impact of this change is high as it is used in the static methods in Phaser.Utils.Arrays: CountAllMatching, EachInRange, GetAll, GetFirst, RemoveBetween, SetAll. These methods are used throughout, for example, in Phaser.GameObjects.Group::getMatching.
