### PR TITLE
Bugfix: PolygonCanvasRenderer: check for closePath when rendering Polygon with Phaser.CANVAS

### DIFF
--- a/src/gameobjects/shape/polygon/PolygonCanvasRenderer.js
+++ b/src/gameobjects/shape/polygon/PolygonCanvasRenderer.js
@@ -56,7 +56,7 @@ var PolygonCanvasRenderer = function (renderer, src, camera, parentMatrix)
             ctx.lineTo(px2, py2);
         }
 
-        if(src.closePath) {
+        if (src.closePath) {
             ctx.closePath();
         }
 

--- a/src/gameobjects/shape/polygon/PolygonCanvasRenderer.js
+++ b/src/gameobjects/shape/polygon/PolygonCanvasRenderer.js
@@ -56,7 +56,9 @@ var PolygonCanvasRenderer = function (renderer, src, camera, parentMatrix)
             ctx.lineTo(px2, py2);
         }
 
-        ctx.closePath();
+        if(src.closePath) {
+            ctx.closePath();
+        }
 
         if (src.isFilled)
         {


### PR DESCRIPTION
This PR fixes a bug where a Polygon GameObject ignores closePath when rendering with Phaser.CANVAS. The Polygon respects closePath when Phaser.WEBGL is used.

The code + screenshot below illustrates the disparity between WebGL and Canvas:
```ts
 this.add.polygon(280, 100, data)
    .setClosePath(false) // closePath: boolean is ignored
    .setStrokeStyle(4, 0x000000)
```

https://codepen.io/optimumsuave/pen/abVzweR
![Screen Shot 2022-01-26 at 1 50 08 PM](https://user-images.githubusercontent.com/8495746/151255413-a26b5125-0c60-4b21-8c9b-6a3ef1770b5a.png)

Github Issue: https://github.com/photonstorm/phaser/issues/5983

Other examples where canvas rendering checks the closePath boolean:

[ArcCanvasRenderer](https://github.com/photonstorm/phaser/blob/master/src/gameobjects/shape/arc/ArcCanvasRenderer.js#L47
) (checks for closePath)
[CurveCanvasRenderer](https://github.com/photonstorm/phaser/blob/master/src/gameobjects/shape/curve/CurveCanvasRenderer.js#L59
) (checks for closePath)

Please let me know if I can clarify or improve on this further. Thanks!
