### PR TITLE
Bugfix: WebGLSnapshot: Support custom rendering contexts

### DIFF
--- a/src/renderer/snapshot/WebGLSnapshot.js
+++ b/src/renderer/snapshot/WebGLSnapshot.js
@@ -17,12 +17,12 @@ var GetFastValue = require('../../utils/object/GetFastValue');
  * @function Phaser.Renderer.Snapshot.WebGL
  * @since 3.0.0
  *
- * @param {HTMLCanvasElement} sourceCanvas - The canvas to take a snapshot of.
+ * @param {WebGLRenderingContext} sourceContext - The WebGL context to take a snapshot of.
  * @param {Phaser.Types.Renderer.Snapshot.SnapshotState} config - The snapshot configuration object.
  */
-var WebGLSnapshot = function (sourceCanvas, config)
+var WebGLSnapshot = function (sourceContext, config)
 {
-    var gl = sourceCanvas.getContext('experimental-webgl');
+    var gl = sourceContext;
 
     var callback = GetFastValue(config, 'callback');
     var type = GetFastValue(config, 'type', 'image/png');

--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -2654,7 +2654,7 @@ var WebGLRenderer = new Class({
 
         if (state.callback)
         {
-            WebGLSnapshot(this.canvas, state);
+            WebGLSnapshot(this.gl, state);
 
             state.callback = null;
         }
@@ -2814,7 +2814,7 @@ var WebGLRenderer = new Class({
 
         this.setFramebuffer(framebuffer);
 
-        WebGLSnapshot(this.canvas, state);
+        WebGLSnapshot(this.gl, state);
 
         this.setFramebuffer(currentFramebuffer);
 


### PR DESCRIPTION
This PR **fixes a bug** where **snapshots would fail when given a custom rendering context**, like when using WebGL2.

The following (semi-simplified) code snippet demonstrates the issue:

```ts
// (This assumes the browser supports WebGL2 and the canvas/context is created successfully)
const gl2Canvas = document.createElement("canvas");
const gl2Context = gl2Canvas.getContext("webgl2", {/*...*/});

new Phaser.Game({
  type: Phaser.WEBGL,
  canvas: gl2Canvas,
  context: gl2Context,

  // .. other game settings ..

  scene: {
    create() {
      // This call will error!
      this.renderer.snapshotArea(x, y, width, height, (snapshot)=>{/*...*/});
    }
  }
});
```

The error produced reads:
```
phaser.js:88562 Uncaught TypeError: Cannot read properties of null (reading 'drawingBufferWidth')
    at WebGLSnapshot (phaser.js:88562:1)
    at WebGLRenderer.postRender (phaser.js:83257:1)
    at Game.step (phaser.js:162825:1)
    at TimeStep.step (phaser.js:89366:1)
    at step (phaser.js:89613:1)
```


Examining the code, it seems that the `WebGLSnapshot` function was receiving the game's Canvas and deducing the context to use from there. The issue is that `canvas.getContext('webgl-experimental')` would fail to retrieve the proper/custom WebGL2 context, and go on to produce the error.

**The solution in this PR** is to instead pass in `WebGLRenderer.gl` to `WebGLSnapshot`, removing the need for _any_ `getContext` calls to occur in the snapshot. `WebGLRenderer.init` handles setting `gl` to the proper context when fired, so our custom contexts are covered accordingly ([link](https://github.com/andymikulski/phaser/blob/6108414b75bb7126c9131d6adb321ff6600861c8/src/renderer/webgl/WebGLRenderer.js#L674)).


Please let me know if I can provide any further information! Thank you!
