### PR TITLE
Bugfix: Tween Reset Fix

### DIFF
--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -967,13 +967,16 @@ var Tween = new Class({
             this.state = TWEEN_CONST.ACTIVE;
         }
 
-        this.isSeeking = true;
-
-        do
+        if (toPosition > 0)
         {
-            this.update(0, delta);
+            this.isSeeking = true;
 
-        } while (this.totalProgress < toPosition);
+            do
+            {
+                this.update(0, delta);
+
+            } while (this.totalProgress < toPosition);
+        }
 
         this.isSeeking = false;
 


### PR DESCRIPTION
This PR:
* Fixes a bug

Describe the changes below:
A fix for #5986 

Because the `do/while` loop iterates one time even when `toPosition` is 0, calling `stop(0)` doesn't fully reset the tween to the expected position, instead reverting to zero and iterating the tween by a single delta. Individually, this isn't noticeable, but over time the single-delta changes add up.

Instead, if `toPosition` is 0, the delta-iteration loop is now skipped entirely.

I've verified that `tween.stop()` still works as expected with no `setTo` parameter as well as *0* and non-zero parameters. Additionally,  `tween.play()`, `tween.pause()`, `tween.resume()` and `tween.restart()` all still function as expected.