### PR TITLE
Remove the load complete handlers when stopping a scene

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -1221,6 +1221,11 @@ var SceneManager = new Class({
 
         if (scene && !scene.sys.isTransitioning() && scene.sys.settings.status !== CONST.SHUTDOWN)
         {
+            var loader = scene.sys.load;
+
+            loader.off(LoaderEvents.COMPLETE, this.loadComplete, this);
+            loader.off(LoaderEvents.COMPLETE, this.payloadComplete, this);
+
             scene.sys.shutdown(data);
         }
 


### PR DESCRIPTION
This PR

* Fixes a bug

If you did, e.g.,

    this.scene.start('scene').stop('scene');

with a scene with a load queue, it would shut down, then call create, then change to running.

Fixes #5726 

