### PR TITLE
Fixed WebGL blending that was broken in 3.50. Fix #5565, fix #5996

### DIFF
--- a/src/gameobjects/rendertexture/RenderTexture.js
+++ b/src/gameobjects/rendertexture/RenderTexture.js
@@ -1167,6 +1167,10 @@ var RenderTexture = new Class({
         }
         else
         {
+            if (!this._eraseMode)
+            {
+                this.renderer.setBlendMode(gameObject.blendMode);
+            }
             gameObject.renderWebGL(this.renderer, gameObject, this.camera);
         }
 


### PR DESCRIPTION
This small PR fixes a WebGL blending bug that was introduced in v3.50.0.

**Fixes https://github.com/photonstorm/phaser/issues/5565 and https://github.com/photonstorm/phaser/issues/5996**

### Detail
It looks like when the `renderDirect()` method was introduced, the WebGL blending was mistakenly removed. 
- You can see the [original code from the previous version 3.24.1](https://github.com/photonstorm/phaser/blob/v3.24.1/src/gameobjects/rendertexture/RenderTexture.js#L985-L988)
- I reintroduced this code in case of non-direct rendering