### PR TITLE
Can use dot notation as datakey

### DIFF
--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -11,6 +11,7 @@ var EventEmitter = require('eventemitter3');
 var Events = require('./events');
 var FileTypesManager = require('./FileTypesManager');
 var GetFastValue = require('../utils/object/GetFastValue');
+var GetValue = require('../utils/object/GetValue');
 var PluginCache = require('../plugins/PluginCache');
 var SceneEvents = require('../scene/events');
 var XHRSettings = require('./XHRSettings');
@@ -603,9 +604,12 @@ var LoaderPlugin = new Class({
     addPack: function (pack, packKey)
     {
         //  if no packKey provided we'll add everything to the queue
-        if (packKey && pack.hasOwnProperty(packKey))
+        if (packKey)
         {
-            pack = { packKey: pack[packKey] };
+            var subPack = GetValue(pack, packKey);
+            if (subPack) {
+                pack = { packKey: subPack };
+            }
         }
 
         var total = 0;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Previously, dataKey only can access 1 level child. For example, dataKey `'test1'`

```json
{
    "test1": {
        "files": [
            {
                "type": "image",
                "key": "bolt",
                "url": "assets/images/bolt.png"
            },
        ]
    }
}
```

This PR can access nested pack json data by dot-notation dataKey `'scene0.test1'`

```json
{
    "scene0": {
        "test1": {
            "files": [
                {
                    "type": "image",
                    "key": "bolt",
                    "url": "assets/images/bolt.png"
                }
            ]
        }
    }
}
```
