### PR TITLE
Add enableCapture to createCursorKeys

### DIFF
--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -395,9 +395,11 @@ var KeyboardPlugin = new Class({
      * @method Phaser.Input.Keyboard.KeyboardPlugin#createCursorKeys
      * @since 3.10.0
      *
+     * @param {boolean} [enableCapture=true] - Automatically call `preventDefault` on the native DOM browser event for the key codes being added.
+     *
      * @return {Phaser.Types.Input.Keyboard.CursorKeys} An object containing the properties: `up`, `down`, `left`, `right`, `space` and `shift`.
      */
-    createCursorKeys: function ()
+    createCursorKeys: function (enableCapture=true)
     {
         return this.addKeys({
             up: KeyCodes.UP,
@@ -406,7 +408,7 @@ var KeyboardPlugin = new Class({
             right: KeyCodes.RIGHT,
             space: KeyCodes.SPACE,
             shift: KeyCodes.SHIFT
-        });
+        }, enableCapture);
     },
 
     /**

--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -395,11 +395,11 @@ var KeyboardPlugin = new Class({
      * @method Phaser.Input.Keyboard.KeyboardPlugin#createCursorKeys
      * @since 3.10.0
      *
-     * @param {boolean} [enableCapture=true] - Automatically call `preventDefault` on the native DOM browser event for the key codes being added.
+     * @param {boolean} [enableCapture] - Automatically call `preventDefault` on the native DOM browser event for the key codes being added.
      *
      * @return {Phaser.Types.Input.Keyboard.CursorKeys} An object containing the properties: `up`, `down`, `left`, `right`, `space` and `shift`.
      */
-    createCursorKeys: function (enableCapture=true)
+    createCursorKeys: function (enableCapture)
     {
         return this.addKeys({
             up: KeyCodes.UP,


### PR DESCRIPTION
This was an annoying issue for me, I was using createCursorKeys, and I also had a html textbox, and I couldn't figure out why space wouldn't work. After a long time I found out the reason, and hopefully this helps other people too.

This PR:

* Adds a new feature

Changes:

Adds a param to createCursorKeys, which allows it to emit keypress events as normal. 

