### PR TITLE
Fix kerning for BitmapText

### DIFF
--- a/src/gameobjects/bitmaptext/GetBitmapTextSize.js
+++ b/src/gameobjects/bitmaptext/GetBitmapTextSize.js
@@ -386,7 +386,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
             i: charIndex,
             char: text[i],
             code: charCode,
-            x: (glyph.xOffset + xAdvance) * scale,
+            x: (glyph.xOffset + x) * scale,
             y: (glyph.yOffset + yAdvance) * scale,
             w: glyph.width * scale,
             h: glyph.height * scale,
@@ -397,7 +397,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
             glyph: glyph
         });
 
-        xAdvance += glyph.xAdvance + letterSpacing;
+        xAdvance += glyph.xAdvance + letterSpacing + ((kerningOffset !== undefined) ? kerningOffset : 0);
         lastGlyph = glyph;
         lastCharCode = charCode;
         currentLineWidth = gw * scale;


### PR DESCRIPTION
This PR:

- [ ] Updates the Documentation
- [ ] Adds a new feature
- [x] Fixes a bug

I noticed a quite major bug in GetBitmapTextSize function, causing that kerning was not applied to BitmapText objects at all. In that PR the bug is fixed and bitmap textfields renders properly.

Details:
---


Kerning was read properly. Local 'x' variable was modified by the kerning also properly. But in the end of the loop's code local 'x' variable was not used to describe character object, then stored in 'characters' return array (out).

In the fix 'x' variable is used as intended to describe particular characters in the output array – instead of general xAdvance, that is not modified with the kerning value read in the loop from glyph object.
Also xAdvance is now modified by kerningOffset to provide consistency between proceeding characters


<img width="299" alt="pre" src="https://user-images.githubusercontent.com/3097623/154123417-37dc484b-0e48-4004-8eee-e25048da458f.png">
<img width="289" alt="now" src="https://user-images.githubusercontent.com/3097623/154123433-b8f522eb-6ffa-47f2-9f84-c64015934ca5.png">

