### PR TITLE
Fix kerning in BitmapText rendering

### DIFF
--- a/src/gameobjects/bitmaptext/GetBitmapTextSize.js
+++ b/src/gameobjects/bitmaptext/GetBitmapTextSize.js
@@ -386,7 +386,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
             i: charIndex,
             char: text[i],
             code: charCode,
-            x: (glyph.xOffset + xAdvance) * scale,
+            x: (glyph.xOffset + x) * scale,
             y: (glyph.yOffset + yAdvance) * scale,
             w: glyph.width * scale,
             h: glyph.height * scale,
@@ -397,7 +397,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
             glyph: glyph
         });
 
-        xAdvance += glyph.xAdvance + letterSpacing;
+        xAdvance += glyph.xAdvance + letterSpacing + ((kerningOffset !== undefined) ? kerningOffset : 0);
         lastGlyph = glyph;
         lastCharCode = charCode;
         currentLineWidth = gw * scale;


### PR DESCRIPTION
This PR:

- [ ] Updates the Documentation
- [ ] Adds a new feature
- [x] Fixes a bug

I noticed a quite major bug in the GetBitmapTextSize function, causing kerning not being applied to BitmapText objects. In the PR the bug is fixed and bitmap textfields are rendered properly.

Details:
---


Kerning values are read properly from glyph data. Local 'x' variable is modified by the kerning value also properly. But at the end of the loop's code local 'x' variable was not used to describe the character object, which is then stored in the 'characters' return array (out).

In the fix 'x' variable is used as intended to describe particular characters in the output array instead of general xAdvance.
Also xAdvance is now modified by kerningOffset to provide consistency between adjacent characters (necessary to place the next character at proper position)

-----

Below is an example illustration of how the bug impacts on characters in a textfield ([Jost](https://fonts.google.com/share?selection.family=Jost:wght@500) font):

<img width="299" alt="pre" src="https://user-images.githubusercontent.com/3097623/154123417-37dc484b-0e48-4004-8eee-e25048da458f.png">

Original font sample:
<img width="195" alt="Zrzut ekranu 2022-02-18 o 14 33 26" src="https://user-images.githubusercontent.com/3097623/154692237-51429fef-29f1-4353-a0bf-b972eeb811cb.png">


------

On the second image, that uses the modified code, the Y character is placed as in the original font. Space is slightly smaller and the general effect more consistent.

<img width="289" alt="now" src="https://user-images.githubusercontent.com/3097623/154123433-b8f522eb-6ffa-47f2-9f84-c64015934ca5.png">


