### PR TITLE
Bugfix: RenderTexture: Fix `fill` on Canvas always appearing black

### DIFF
--- a/src/gameobjects/rendertexture/RenderTexture.js
+++ b/src/gameobjects/rendertexture/RenderTexture.js
@@ -508,9 +508,9 @@ var RenderTexture = new Class({
         if (width === undefined) { width = frame.cutWidth; }
         if (height === undefined) { height = frame.cutHeight; }
 
-        var r = (rgb >> 16 & 0xFF) / 255;
-        var g = (rgb >> 8 & 0xFF) / 255;
-        var b = (rgb & 0xFF) / 255;
+        var r = (rgb >> 16 & 0xFF);
+        var g = (rgb >> 8 & 0xFF);
+        var b = (rgb & 0xFF);
 
         var renderTarget = this.renderTarget;
 
@@ -535,7 +535,7 @@ var RenderTexture = new Class({
 
             pipeline.drawFillRect(
                 x * sx, y * sy, width * sx, height * sy,
-                Utils.getTintFromFloats(b, g, r, 1),
+                Utils.getTintFromFloats(b / 255, g / 255, r / 255, 1),
                 alpha
             );
 


### PR DESCRIPTION
This PR **fixes a bug** where **when in Canvas mode, fills on a RenderTexture would always be near-black**.

![image](https://user-images.githubusercontent.com/2767162/155249120-2cc3b599-9cc6-42ad-bc3a-b48ac72356af.png)


The snippet of bugged code can be boiled down to using `Phaser.CANVAS` and `RenderTexture.fill` - also demonstrated in [this codepen](https://codepen.io/andymikulski/pen/QWOxdEW):
```
new Phaser.Game({
  width: 250,
  height: 250,
  type: Phaser.CANVAS, // Change to `Phaser.WEBGL` to for correct functionality
  backgroundColor: 0xFFFFFF,
  scene: {
    create: function() {
      const rt = this.add.renderTexture(0,0,100,100);
      rt.fill(0xff0000);
      // OBSERVE: RenderTexture appears entirely black
    }
  }
});
```

Examining the code, the RGB values in `fill` are scaled from `0-255` to `0-1`, as the 'float' values are used in the WebGL renderer. The problem, though, is that canvas needs the 255 values - currently the values are being fed in as `rgba(0.5, 0.25, .025, 1)` (for example), which simply appears as black or near-black.

**The solution in this PR** is to simply only scale the RGB values when the RenderTexture is using WebGL.