### PR TITLE
Improve the scene start logic

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -1125,7 +1125,9 @@ var SceneManager = new Class({
     },
 
     /**
-     * Starts the given Scene.
+     * Starts the given Scene, if it is not starting, loading, or creating.
+     *
+     * If the Scene is running, paused, or sleeping, it will be shutdown and then started.
      *
      * @method Phaser.Scenes.SceneManager#start
      * @since 3.0.0
@@ -1157,10 +1159,18 @@ var SceneManager = new Class({
         }
 
         var sys = scene.sys;
+        var status = sys.settings.status;
 
-        //  If the Scene is already running (perhaps they called start from a launched sub-Scene?)
-        //  then we close it down before starting it again.
-        if (sys.isActive() || sys.isPaused())
+        //  If the scene is already started but not yet running,
+        //  let it continue.
+        if (status >= CONST.START && status <= CONST.CREATING)
+        {
+            return this;
+        }
+
+        //  If the Scene is already running, paused, or sleeping,
+        //  close it down before starting it again.
+        else if (status >= CONST.RUNNING && status <= CONST.SLEEPING)
         {
             sys.shutdown();
 
@@ -1168,6 +1178,9 @@ var SceneManager = new Class({
 
             sys.start(data);
         }
+
+        //  If the Scene is INIT or SHUTDOWN,
+        //  start it directly.
         else
         {
             sys.sceneUpdate = NOOP;


### PR DESCRIPTION
This PR

* Adds a new feature

These changes avoid some problems when starting scenes (#5999):

- If you start a scene that is already starting (`START`, `LOADING`, or `CREATING`), the start operation is ignored. (But since #5997 you can force the scene to restart by shutting it down first, if you want.)
- If you start a scene that is sleeping, it's shut down before starting again. This matches how Phaser currently handles paused scenes.

