### PR TITLE
Fix issue: hitAreaCallback type definition #5954

### DIFF
--- a/scripts/tsgen/src/Parser.ts
+++ b/scripts/tsgen/src/Parser.ts
@@ -433,7 +433,11 @@ export class Parser {
 
         } else {
             if (doclet.type.names[0] == "function") {
-                type = dom.create.functionType(null, dom.type.void);
+                let returnType: dom.Type = dom.type.void;
+                if (doclet.returns) {
+                    returnType = this.parseType(doclet.returns[0]);
+                }
+                type = dom.create.functionType(null, returnType);
                 this.setParams(doclet, type);
             } else {
                 type = this.parseType(doclet);


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

When parser created a `Typedef` and it was a function, we ignored the `returns` and just used static `dom.type.void`

This code is copied `createFunction` which picked the return type correctly. 