### PR TITLE
Handle nullable in parser.parseType

### DIFF
--- a/scripts/tsgen/src/Parser.ts
+++ b/scripts/tsgen/src/Parser.ts
@@ -486,7 +486,7 @@ export class Parser {
                     continue;
                 }
 
-                let param = dom.create.parameter(paramDoc.name, this.parseType(paramDoc));
+                let param = dom.create.parameter(paramDoc.name, this.parseType(paramDoc, dom.type.undefined));
                 parameters.push(param);
 
                 if (optional && paramDoc.optional != true) {
@@ -510,7 +510,7 @@ export class Parser {
         obj.parameters = parameters;
     }
 
-    private parseType(typeDoc: any): dom.Type {
+    private parseType(typeDoc: any, nullableType = dom.type.null): dom.Type {
         if (!typeDoc || !typeDoc.type) {
             return dom.type.any;
         } else {
@@ -524,7 +524,7 @@ export class Parser {
                 types.push(type);
             }
             if (typeDoc.nullable) {
-                types.push(dom.type.null);
+                types.push(nullableType);
             }
             if (types.length == 1) return types[0];
             else return dom.create.union(types);

--- a/scripts/tsgen/src/Parser.ts
+++ b/scripts/tsgen/src/Parser.ts
@@ -523,6 +523,9 @@ export class Parser {
 
                 types.push(type);
             }
+            if (typeDoc.nullable) {
+                types.push(dom.type.null);
+            }
             if (types.length == 1) return types[0];
             else return dom.create.union(types);
         }


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes missing type script return type `null`

Describe the changes below:
Nullable flag was ignored, which makes all functions that can return `null` not containing the type for it.

This adds the null return type, to all such functions.

This is an issue, because ts doesn't know the function can return null, which can easily lead to bugs.

**Please Note**
This will make all ts based projects to fail type check, if there is no null check, when using functions that can return null.

**Example**
before:
```
/**
 * Retrieves a Scene.
 * @param key The Scene to retrieve.
 */
getScene(key: string | Phaser.Scene): Phaser.Scene;
```
after:
```
/**
 * Retrieves a Scene.
 * @param key The Scene to retrieve.
 */
getScene(key: string | Phaser.Scene): Phaser.Scene | null;
```