### PR TITLE
Destroy game objects safely in layer.destroy()

### DIFF
--- a/src/gameobjects/layer/Layer.js
+++ b/src/gameobjects/layer/Layer.js
@@ -933,6 +933,8 @@ var Layer = new Class({
      * @method Phaser.GameObjects.Layer#destroy
      * @fires Phaser.GameObjects.Events#DESTROY
      * @since 3.50.0
+     * 
+     * @param {boolean} [fromScene=false] - `True` if this Game Object is being destroyed by the Scene, `false` if not.
      */
     destroy: function (fromScene)
     {

--- a/src/gameobjects/layer/Layer.js
+++ b/src/gameobjects/layer/Layer.js
@@ -934,7 +934,7 @@ var Layer = new Class({
      * @fires Phaser.GameObjects.Events#DESTROY
      * @since 3.50.0
      */
-    destroy: function ()
+    destroy: function (fromScene)
     {
         //  This Game Object has already been destroyed
         if (!this.scene || this.ignoreDestroy)
@@ -944,11 +944,11 @@ var Layer = new Class({
 
         this.emit(GameObjectEvents.DESTROY, this);
 
-        var i = this.list.length;
+        var list = this.list;
 
-        while (i--)
+        while (list.length)
         {
-            this.list[i].destroy();
+            list[0].destroy(fromScene);
         }
 
         this.removeAllListeners();


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The logic references from #5953 

Children of layer might be destroyed internally, thus the list length will be changed. 

Also bypass the `fromScene` parameter to children.
