### PR TITLE
Add setCrop method to BitmapText game object

### DIFF
--- a/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextCanvasRenderer.js
+++ b/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextCanvasRenderer.js
@@ -93,10 +93,10 @@ var DynamicBitmapTextCanvasRenderer = function (renderer, src, camera, parentMat
 
     var roundPixels = camera.roundPixels;
 
-    if (src.cropWidth > 0 && src.cropHeight > 0)
+    if (src.isCropped)
     {
         ctx.beginPath();
-        ctx.rect(0, 0, src.cropWidth, src.cropHeight);
+        ctx.rect(src.cropX, src.cropY, src.cropWidth, src.cropHeight);
         ctx.clip();
     }
 

--- a/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextWebGLRenderer.js
+++ b/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextWebGLRenderer.js
@@ -45,15 +45,13 @@ var DynamicBitmapTextWebGLRenderer = function (renderer, src, camera, parentMatr
 
     var fontMatrix = tempMatrix;
 
-    var crop = (src.cropWidth > 0 || src.cropHeight > 0);
-
-    if (crop)
+    if (src.isCropped)
     {
         pipeline.flush();
 
         renderer.pushScissor(
-            calcMatrix.tx,
-            calcMatrix.ty,
+            (src.cropX * calcMatrix.scaleX) + calcMatrix.tx,
+            (src.cropY * calcMatrix.scaleY) + calcMatrix.ty,
             src.cropWidth * calcMatrix.scaleX,
             src.cropHeight * calcMatrix.scaleY
         );
@@ -269,7 +267,7 @@ var DynamicBitmapTextWebGLRenderer = function (renderer, src, camera, parentMatr
         pipeline.batchQuad(src, tx0, ty0, tx1, ty1, tx2, ty2, tx3, ty3, u0, v0, u1, v1, tintTL, tintTR, tintBL, tintBR, tintEffect, texture, textureUnit);
     }
 
-    if (crop)
+    if (src.isCropped)
     {
         pipeline.flush();
 

--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -274,6 +274,58 @@ var BitmapText = new Class({
          */
         this.fromAtlas = entry.fromAtlas;
 
+        /**
+         * A boolean flag indicating if this Game Object is being cropped or not.
+         * You can toggle this at any time after `setCrop` has been called, to turn cropping on or off.
+         * Equally, calling `setCrop` with no arguments will reset the crop and disable it.
+         *
+         * @name Phaser.GameObjects.BitmapText#isCropped
+         * @type {boolean}
+         * @since 3.60.0
+         */
+        this.isCropped = false;
+
+        /**
+         * The x coordinate to start the crop from.
+         *
+         * @name Phaser.GameObjects.BitmapText#cropX
+         * @type {number}
+         * @default 0
+         * @since 3.60.0
+         */
+        this.cropX = 0;
+ 
+        /**
+         * The y coordinate to start the crop from.
+         *
+         * @name Phaser.GameObjects.BitmapText#cropY
+         * @type {number}
+         * @default 0
+         * @since 3.60.0
+         */
+        this.cropY = 0;
+ 
+        /**
+         * The crop width of the Bitmap Text.
+         *
+         * @name Phaser.GameObjects.BitmapText#cropWidth
+         * @type {number}
+         * @default 0
+         * @since 3.0.0
+         */
+        this.cropWidth = 0;
+ 
+        /**
+         * The crop height of the Bitmap Text.
+         *
+         * @name Phaser.GameObjects.BitmapText#cropHeight
+         * @type {number}
+         * @default 0
+         * @since 3.0.0
+         */
+        this.cropHeight = 0;
+ 
+
         this.setTexture(entry.texture, entry.frame);
         this.setPosition(x, y);
         this.setOrigin(0, 0);
@@ -631,6 +683,63 @@ var BitmapText = new Class({
             }
         }
 
+        return this;
+    },
+
+
+    /**
+     * Applies a crop to this Bitmap Text.
+     *
+     * The crop is a rectangle that limits the area of this Bitmap Text that is visible during rendering.
+     *
+     * Cropping a Game Object does not change its size, dimensions, physics body or hit area, it just
+     * changes what is shown when rendered.
+     * You can either pass in numeric values directly, or you can provide a single Rectangle object as the first argument.
+     *
+     * Call this method with no arguments at all to reset the crop, or toggle the property `isCropped` to `false`.
+     *
+     * You should do this if the crop rectangle becomes the same size as this Bitmap Text itself, as it will allow
+     * the renderer to skip several internal calculations.
+     *
+     * @method Phaser.GameObjects.DynamicBitmapText#setCrop
+     * @since 3.60.0
+     *
+     * @param {(number|Phaser.Geom.Rectangle)} [x] - The x coordinate to start the crop from. Or a Phaser.Geom.Rectangle object, in which case the rest of the arguments are ignored.
+     * @param {number} [y] - The y coordinate to start the crop from.
+     * @param {number} [width] - The width of the crop rectangle in pixels.
+     * @param {number} [height] - The height of the crop rectangle in pixels.
+     *
+     * @return {this} This Game Object instance.
+     */
+    setCrop: function (x, y, width, height)
+    {
+        if (x === undefined)
+        {
+            this.isCropped = false;
+        }
+        else
+        {
+            if (typeof x === 'number')
+            {
+                this.cropX = x;
+                this.cropY = y;
+                this.cropWidth = width;
+                this.cropHeight = height;
+ 
+            }
+            else
+            {
+                var rect = x;
+ 
+                this.cropX = rect.x;
+                this.cropY = rect.y;
+                this.cropWidth = rect.width;
+                this.cropHeight = rect.height;
+            }
+ 
+            this.isCropped = true;
+        }
+ 
         return this;
     },
 

--- a/src/gameobjects/bitmaptext/static/BitmapTextCanvasRenderer.js
+++ b/src/gameobjects/bitmaptext/static/BitmapTextCanvasRenderer.js
@@ -95,6 +95,13 @@ var BitmapTextCanvasRenderer = function (renderer, src, camera, parentMatrix)
 
     var roundPixels = camera.roundPixels;
 
+    if (src.isCropped)
+    {
+        ctx.beginPath();
+        ctx.rect(src.cropX, src.cropY, src.cropWidth, src.cropHeight);
+        ctx.clip();
+    }
+
     for (var i = 0; i < textLength; i++)
     {
         charCode = text.charCodeAt(i);

--- a/src/gameobjects/bitmaptext/static/BitmapTextWebGLRenderer.js
+++ b/src/gameobjects/bitmaptext/static/BitmapTextWebGLRenderer.js
@@ -38,6 +38,18 @@ var BitmapTextWebGLRenderer = function (renderer, src, camera, parentMatrix)
 
     var calcMatrix = GetCalcMatrix(src, camera, parentMatrix).calc;
 
+    if (src.isCropped)
+    {
+        pipeline.flush();
+
+        renderer.pushScissor(
+            (src.cropX * calcMatrix.scaleX) + calcMatrix.tx,
+            (src.cropY * calcMatrix.scaleY) + calcMatrix.ty,
+            src.cropWidth * calcMatrix.scaleX,
+            src.cropHeight * calcMatrix.scaleY
+        );
+    }
+
     var roundPixels = camera.roundPixels;
 
     var cameraAlpha = camera.alpha;
@@ -125,6 +137,13 @@ var BitmapTextWebGLRenderer = function (renderer, src, camera, parentMatrix)
 
         //  Debug test if the characters are in the correct place when rendered:
         // pipeline.drawFillRect(tx0, ty0, tx2 - tx0, ty2 - ty0, 0x00ff00, 0.5);
+    }
+
+    if (src.isCropped)
+    {
+        pipeline.flush();
+
+        renderer.popScissor();
     }
 
     renderer.pipelines.postBatch(src);


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Add `setCrop` method to BitmapText game object.