### PR TITLE
Allow moving particles to (0, 0)

### DIFF
--- a/src/gameobjects/particles/EmitterOp.js
+++ b/src/gameobjects/particles/EmitterOp.js
@@ -238,6 +238,12 @@ var EmitterOp = new Class({
         this.onEmit = this.defaultEmit;
         this.onUpdate = this.defaultUpdate;
 
+        //  `moveToX` and `moveToY` are null by default
+        if (value === null)
+        {
+            return;
+        }
+
         if (t === 'number')
         {
             //  Explicit static value:

--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -303,7 +303,7 @@ var ParticleEmitter = new Class({
         this.speedY = new EmitterOp(config, 'speedY', 0, true);
 
         /**
-         * Whether moveToX and moveToY are nonzero. Set automatically during configuration.
+         * Whether moveToX and moveToY are set. Set automatically during configuration.
          *
          * @name Phaser.GameObjects.Particles.ParticleEmitter#moveTo
          * @type {boolean}
@@ -320,7 +320,7 @@ var ParticleEmitter = new Class({
          * @default 0
          * @since 3.0.0
          */
-        this.moveToX = new EmitterOp(config, 'moveToX', 0, true);
+        this.moveToX = new EmitterOp(config, 'moveToX', null, true);
 
         /**
          * The y-coordinate emitted particles move toward, when {@link Phaser.GameObjects.Particles.ParticleEmitter#moveTo} is true.
@@ -330,7 +330,7 @@ var ParticleEmitter = new Class({
          * @default 0
          * @since 3.0.0
          */
-        this.moveToY = new EmitterOp(config, 'moveToY', 0, true);
+        this.moveToY = new EmitterOp(config, 'moveToY', null, true);
 
         /**
          * Whether particles will rebound when they meet the emitter bounds.
@@ -806,7 +806,7 @@ var ParticleEmitter = new Class({
 
         this.acceleration = (this.accelerationX.propertyValue !== 0 || this.accelerationY.propertyValue !== 0);
 
-        this.moveTo = (this.moveToX.propertyValue !== 0 || this.moveToY.propertyValue !== 0);
+        this.moveTo = (this.moveToX.propertyValue !== null && this.moveToY.propertyValue !== null);
 
         //  Special 'speed' override
 


### PR DESCRIPTION
This PR

* Adds a new feature

It wasn't possible to move particles to (0, 0), so I added it.

`moveToX` and `moveToY` now default to `null` instead of `0`.

NB both `moveToX` and `moveToY` must now be set (even if 0) to enable to move-to behavior. This is a slight change from v3.55.2.
