### PR TITLE
Fix kerning for BitmapText on Canvas renderer

### DIFF
--- a/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextCanvasRenderer.js
+++ b/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextCanvasRenderer.js
@@ -173,7 +173,7 @@ var DynamicBitmapTextCanvasRenderer = function (renderer, src, camera, parentMat
 
         x += lineOffsetX;
 
-        xAdvance += glyph.xAdvance + letterSpacing;
+        xAdvance += glyph.xAdvance + letterSpacing + ((kerningOffset !== undefined) ? kerningOffset : 0);
         lastGlyph = glyph;
         lastCharCode = charCode;
 

--- a/src/gameobjects/bitmaptext/static/BitmapTextCanvasRenderer.js
+++ b/src/gameobjects/bitmaptext/static/BitmapTextCanvasRenderer.js
@@ -146,7 +146,7 @@ var BitmapTextCanvasRenderer = function (renderer, src, camera, parentMatrix)
 
         x += lineOffsetX;
 
-        xAdvance += glyph.xAdvance + letterSpacing;
+        xAdvance += glyph.xAdvance + letterSpacing + ((kerningOffset !== undefined) ? kerningOffset : 0);
         lastGlyph = glyph;
         lastCharCode = charCode;
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

#6012 resolved an issue where BitmapText did not take kerning into account when positioning letters. However, the canvas renderer for BitmapText uses almost exactly the same code, and was not updated to apply the same fix. This copies the change to xAdvance, ensuring that the kerning offset is used when calculating the next letter's position on non-WebGL.