### PR TITLE
Don't reassign the return values from require()

### DIFF
--- a/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextRender.js
+++ b/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/bitmaptext/static/BitmapTextRender.js
+++ b/src/gameobjects/bitmaptext/static/BitmapTextRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/blitter/BlitterRender.js
+++ b/src/gameobjects/blitter/BlitterRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/container/ContainerRender.js
+++ b/src/gameobjects/container/ContainerRender.js
@@ -5,8 +5,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/domelement/DOMElementRender.js
+++ b/src/gameobjects/domelement/DOMElementRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/extern/ExternRender.js
+++ b/src/gameobjects/extern/ExternRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/graphics/GraphicsRender.js
+++ b/src/gameobjects/graphics/GraphicsRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/image/ImageRender.js
+++ b/src/gameobjects/image/ImageRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/layer/LayerRender.js
+++ b/src/gameobjects/layer/LayerRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/mesh/MeshRender.js
+++ b/src/gameobjects/mesh/MeshRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/particles/ParticleManagerRender.js
+++ b/src/gameobjects/particles/ParticleManagerRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/pointlight/PointLightRender.js
+++ b/src/gameobjects/pointlight/PointLightRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/rendertexture/RenderTextureRender.js
+++ b/src/gameobjects/rendertexture/RenderTextureRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/rope/RopeRender.js
+++ b/src/gameobjects/rope/RopeRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shader/ShaderRender.js
+++ b/src/gameobjects/shader/ShaderRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/arc/ArcRender.js
+++ b/src/gameobjects/shape/arc/ArcRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/curve/CurveRender.js
+++ b/src/gameobjects/shape/curve/CurveRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/ellipse/EllipseRender.js
+++ b/src/gameobjects/shape/ellipse/EllipseRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/grid/GridRender.js
+++ b/src/gameobjects/shape/grid/GridRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/isobox/IsoBoxRender.js
+++ b/src/gameobjects/shape/isobox/IsoBoxRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/isotriangle/IsoTriangleRender.js
+++ b/src/gameobjects/shape/isotriangle/IsoTriangleRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/line/LineRender.js
+++ b/src/gameobjects/shape/line/LineRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/polygon/PolygonRender.js
+++ b/src/gameobjects/shape/polygon/PolygonRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/rectangle/RectangleRender.js
+++ b/src/gameobjects/shape/rectangle/RectangleRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/star/StarRender.js
+++ b/src/gameobjects/shape/star/StarRender.js
@@ -5,6 +5,7 @@
  */
 
 var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/star/StarRender.js
+++ b/src/gameobjects/shape/star/StarRender.js
@@ -4,8 +4,7 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/shape/triangle/TriangleRender.js
+++ b/src/gameobjects/shape/triangle/TriangleRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../../utils/NOOP');
-var renderCanvas = require('../../../utils/NOOP');
+var NOOP = require('../../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/sprite/SpriteRender.js
+++ b/src/gameobjects/sprite/SpriteRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/text/TextRender.js
+++ b/src/gameobjects/text/TextRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/tilesprite/TileSpriteRender.js
+++ b/src/gameobjects/tilesprite/TileSpriteRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/gameobjects/video/VideoRender.js
+++ b/src/gameobjects/video/VideoRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../../utils/NOOP');
-var renderCanvas = require('../../utils/NOOP');
+var NOOP = require('../../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {

--- a/src/tilemaps/TilemapLayerRender.js
+++ b/src/tilemaps/TilemapLayerRender.js
@@ -4,8 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var renderWebGL = require('../utils/NOOP');
-var renderCanvas = require('../utils/NOOP');
+var NOOP = require('../utils/NOOP');
+var renderWebGL = NOOP, renderCanvas = NOOP;
 
 if (typeof WEBGL_RENDERER)
 {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

This is a bit weird, but when processing Phaser with Google's closure-compiler, it doesn't like when a variable from require() is reassigned to a new value (see: google/closure-compiler#3363).

This should be functionally the same, but in a way that pleases closure-compiler. These render modules are the only ones I saw that run into this case.