### PR TITLE
Update bitecs devDependency to dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.2.2",
             "license": "MIT",
             "dependencies": {
+                "bitecs": "^0.3.21-13",
                 "sloc": "^0.2.1"
             },
             "devDependencies": {
@@ -18,7 +19,6 @@
                 "@types/jest": "^27.0.2",
                 "@typescript-eslint/eslint-plugin": "4.33.0",
                 "@typescript-eslint/parser": "4.33.0",
-                "bitecs": "^0.3.21-13",
                 "boxen": "^6.2.0",
                 "directory-tree": "^3.0.0",
                 "esbuild": "^0.13.4",
@@ -1144,8 +1144,7 @@
         "node_modules/bitecs": {
             "version": "0.3.21-13",
             "resolved": "https://registry.npmjs.org/bitecs/-/bitecs-0.3.21-13.tgz",
-            "integrity": "sha512-N0VCjiYg3XoyFzCu7xZacyGWDVwpFb8y3X4sdycx8IjkGGyVtYSJpCyffOUKzNXU0pIhyYWXHoswNxiAlkNOzg==",
-            "dev": true
+            "integrity": "sha512-N0VCjiYg3XoyFzCu7xZacyGWDVwpFb8y3X4sdycx8IjkGGyVtYSJpCyffOUKzNXU0pIhyYWXHoswNxiAlkNOzg=="
         },
         "node_modules/boxen": {
             "version": "6.2.0",
@@ -7104,8 +7103,7 @@
         "bitecs": {
             "version": "0.3.21-13",
             "resolved": "https://registry.npmjs.org/bitecs/-/bitecs-0.3.21-13.tgz",
-            "integrity": "sha512-N0VCjiYg3XoyFzCu7xZacyGWDVwpFb8y3X4sdycx8IjkGGyVtYSJpCyffOUKzNXU0pIhyYWXHoswNxiAlkNOzg==",
-            "dev": true
+            "integrity": "sha512-N0VCjiYg3XoyFzCu7xZacyGWDVwpFb8y3X4sdycx8IjkGGyVtYSJpCyffOUKzNXU0pIhyYWXHoswNxiAlkNOzg=="
         },
         "boxen": {
             "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "@types/jest": "^27.0.2",
         "@typescript-eslint/eslint-plugin": "4.33.0",
         "@typescript-eslint/parser": "4.33.0",
-        "bitecs": "^0.3.21-13",
         "boxen": "^6.2.0",
         "directory-tree": "^3.0.0",
         "esbuild": "^0.13.4",
@@ -54,6 +53,7 @@
         "uplot": "^1.6.16"
     },
     "dependencies": {
-        "sloc": "^0.2.1"
+        "sloc": "^0.2.1",
+        "bitecs": "^0.3.21-13"
     }
 }


### PR DESCRIPTION
Missing dependency `bitecs` when initial installing phaser 4.  

This is listed in the package.json as a devDependency which causes it not to be installed when it is a dependency.  

Workaround: 
- Developer has to install the missing package

Fix:
- move to dependency list so it's installed 