### PR TITLE
Allow input debug hit area colour to be adjusted after enabling.

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -2486,10 +2486,11 @@ var InputPlugin = new Class({
         if (debug)
         {
             debug.isFilled = false;
+            debug.strokeColor = color;
 
             debug.preUpdate = function ()
             {
-                debug.setStrokeStyle(1 / gameObject.scale, color);
+                debug.setStrokeStyle(1 / gameObject.scale, debug.strokeColor);
 
                 debug.setDisplayOrigin(gameObject.displayOriginX, gameObject.displayOriginY);
 


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The docs say that the Debug Shape for input debugging, can be accessed and modified via the Game Object property 'hitAreaDebug' but preUpdate function always uses the colour specified when enabling, so changes to the 'strokeColor' property are ignored.

This update allows changes to the gameObject.hitAreaDebug.strokeColor to affect the colour of the hit area outline.

Possibly this is a new feature, but it feels more like this was the intended behaviour.
