### PR TITLE
FIX: ImageFile addCache pending destruction status

### DIFF
--- a/src/loader/filetypes/ImageFile.js
+++ b/src/loader/filetypes/ImageFile.js
@@ -203,7 +203,7 @@ var ImageFile = new Class({
     {
         var linkFile = this.linkFile;
 
-        if (linkFile && linkFile.state === CONST.FILE_COMPLETE)
+        if (linkFile && linkFile.state >= CONST.FILE_COMPLETE)
         {
             if (this.type === 'image')
             {


### PR DESCRIPTION
This PR fixes a bug with failed loading of linked files if one of them is already scheduled for destruction,  addrresses #6042 reported earlier. 

Describe the changes below:

This migh not be the only change necessary as the change expects all status codes above FILE_COMPLETE to be results of successful load. This is quite efficient approach yet quite implicit. Alternatively a list of acceptable states should be enough.
