### PR TITLE
Fix frame durations when creating animations with createFromAseprite function

### DIFF
--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -433,10 +433,8 @@ var AnimationManager = new Class({
 
                 if (!tags || (tags && tags.indexOf(name) > -1))
                 {
-                    //  Get all the frames for this tag
-                    var tempFrames = [];
-                    var minDuration = Number.MAX_SAFE_INTEGER;
-
+                    //  Get all the frames for this tag and calculate the total duration in milliseconds.
+                    var totalDuration = 0;
                     for (var i = from; i <= to; i++)
                     {
                         var frameKey = i.toString();
@@ -445,26 +443,16 @@ var AnimationManager = new Class({
                         if (frame)
                         {
                             var frameDuration = GetFastValue(frame, 'duration', Number.MAX_SAFE_INTEGER);
-
-                            if (frameDuration < minDuration)
-                            {
-                                minDuration = frameDuration;
-                            }
-
-                            tempFrames.push({ frame: frameKey, duration: frameDuration });
+                            animFrames.push({ key: key, frame: frameKey, duration: frameDuration });
+                            totalDuration += frameDuration;
                         }
                     }
 
-                    tempFrames.forEach(function (entry)
-                    {
-                        animFrames.push({
-                            key: key,
-                            frame: entry.frame,
-                            duration: (entry.duration - minDuration)
-                        });
+                    // Fix duration to play nice with how the next tick is calculated.
+                    var msPerFrame = totalDuration / animFrames.length;
+                    animFrames.forEach(function(entry) {
+                      entry.duration -= msPerFrame;
                     });
-
-                    var totalDuration = (minDuration * animFrames.length);
 
                     if (direction === 'reverse')
                     {


### PR DESCRIPTION
This PR Fixes a bug.

### Bug description:
I have an animation created using [Aseprite](https://aseprite.org/) with just 3 frames. Each frame has the following durations in milliseconds: [1000, 50, 50].
Then, in Phaser, I create the animation using the `scene.anims.createFromAseprite();` function, and later I call the `sprite.play()` function for such animation with `repeat: -1`. 
In my browser I see that the animation is reproduced super fast, like if each frame had a duration of 1ms or so.

**Code to reproduce it** (the lazy dev can click [this JSFiddle](https://jsfiddle.net/dsey9kzn/))
```javascript
var config = {
    type: Phaser.AUTO,
    parent: 'phaser-example',
    backgroundColor: "#220000",
    width: 32,
    height: 32,
    scene: {
        preload: preload,
        create: create
    }
};

var game = new Phaser.Game(config);

function preload() 
{
    this.load.aseprite('eye', 'https://cdn.jsdelivr.net/gh/martincapello/martincapello.github.io@c44fe0009fc83493b2701de03249b3b4c88009ef/assets/eye.png', 'https://cdn.jsdelivr.net/gh/martincapello/martincapello.github.io@c44fe0009fc83493b2701de03249b3b4c88009ef/assets/eye.json');
}

function create ()
{
    this.anims.createFromAseprite('eye');
    this.add.sprite(16,16,'eye').play({key: 'blink', repeat: -1});
}
```

**How it should look like**
![](https://raw.githubusercontent.com/martincapello/martincapello.github.io/64fd3c890ca57887618145ebda953942c5fba088/assets/eye.gif)


### Changes
I have updated the `createFromAseprite` function to calculate the duration for each frame by first calculating the total duration of the animation, and then distributing that time in a manner that plays nice with [how the next tick of the animations are calculated by Phaser](https://github.com/photonstorm/phaser/blob/9310f8a5a71b84199c91954346cf4df3c1649b5b/src/animations/Animation.js#L478).

After the patch the animation playback is fixed. Tested using Phaser 3.55.2 and latest Chrome, Firefox and Edge browsers.

Tip: If you want to try this fix using my fork on your project you can run
```
$ npm install martincapello/phaser#fix-createFromAseprite  --save-prod
```
This will replace the phaser dependency in your package.json with the `fix-createFromAseprite` branch from my phaser fork. 
