### PR TITLE
Allow particle frequency smaller than delta

### DIFF
--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -2046,12 +2046,12 @@ var ParticleEmitter = new Class({
         {
             this._counter -= delta;
 
-            if (this._counter <= 0)
+            while (this._counter <= 0)
             {
                 this.emitParticle();
 
                 //  counter = frequency - remained from previous delta
-                this._counter = (this.frequency - Math.abs(this._counter));
+                this._counter += this.frequency;
             }
         }
     },


### PR DESCRIPTION
This PR

* Adds a new feature

You could get inconsistent particle throughput when setting a small `frequency`, depending on the game step rate.



