### PR TITLE
Let texture `scaleMode` override the `antialias` setting under `CANVAS`

### DIFF
--- a/src/gameobjects/blitter/BlitterCanvasRenderer.js
+++ b/src/gameobjects/blitter/BlitterCanvasRenderer.js
@@ -42,7 +42,7 @@ var BlitterCanvasRenderer = function (renderer, src, camera, parentMatrix)
     //  Blend Mode + Scale Mode
     ctx.globalCompositeOperation = renderer.blendModes[src.blendMode];
 
-    ctx.imageSmoothingEnabled = !(!renderer.antialias || src.frame.source.scaleMode);
+    ctx.imageSmoothingEnabled = !src.frame.source.scaleMode;
 
     var cameraScrollX = src.x - camera.scrollX * src.scrollFactorX;
     var cameraScrollY = src.y - camera.scrollY * src.scrollFactorY;

--- a/src/gameobjects/particles/ParticleManagerCanvasRenderer.js
+++ b/src/gameobjects/particles/ParticleManagerCanvasRenderer.js
@@ -120,7 +120,7 @@ var ParticleManagerCanvasRenderer = function (renderer, emitterManager, camera, 
                     y = Math.round(y);
                 }
 
-                ctx.imageSmoothingEnabled = !(!renderer.antialias || frame.source.scaleMode);
+                ctx.imageSmoothingEnabled = !frame.source.scaleMode;
 
                 ctx.drawImage(frame.source.image, cd.x, cd.y, cd.width, cd.height, x, y, cd.width, cd.height);
 

--- a/src/renderer/canvas/CanvasRenderer.js
+++ b/src/renderer/canvas/CanvasRenderer.js
@@ -811,7 +811,7 @@ var CanvasRenderer = new Class({
 
         ctx.globalAlpha = alpha;
 
-        ctx.imageSmoothingEnabled = !(!this.antialias || frame.source.scaleMode);
+        ctx.imageSmoothingEnabled = !frame.source.scaleMode;
 
         if (sprite.mask)
         {

--- a/src/renderer/canvas/utils/SetTransform.js
+++ b/src/renderer/canvas/utils/SetTransform.js
@@ -16,7 +16,8 @@ var GetCalcMatrix = require('../../../gameobjects/GetCalcMatrix');
  * 4. Sets the alpha value of the context to be that used by the Game Object combined with the Camera.
  * 5. Saves the context state.
  * 6. Sets the final matrix values into the context via setTransform.
- * 7. If Renderer.antialias, or the frame.source.scaleMode is set, then imageSmoothingEnabled is set.
+ * 7. If the Game Object has a texture frame, imageSmoothingEnabled is set based on frame.source.scaleMode.
+ * 8. If the Game Object does not have a texture frame, imageSmoothingEnabled is set based on Renderer.antialias.
  *
  * This function is only meant to be used internally. Most of the Canvas Renderer classes use it.
  *
@@ -53,7 +54,7 @@ var SetTransform = function (renderer, ctx, src, camera, parentMatrix)
 
     calcMatrix.setToContext(ctx);
 
-    ctx.imageSmoothingEnabled = !(!renderer.antialias || (src.frame && src.frame.source.scaleMode));
+    ctx.imageSmoothingEnabled = src.frame ? !src.frame.source.scaleMode : renderer.antialias;
 
     return true;
 };


### PR DESCRIPTION
**This PR**
* Updates the Documentation
* Fixes a bug

**Describe the changes below:**
My understanding has always been that linear texture filtering or canvas image smoothing will be used if `antialias` is true, or if the texture in question has its `scaleMode` set to `LINEAR` (0).

This holds true for the WebGL renderer, but doesn't seem to be case under the Canvas renderer.

I had a look and noticed that there are a number of statements of the form:
```
ctx.imageSmoothingEnabled = !(!antialias || frame.source.scaleMode);
```
This will short-circuit if `antialias` is disabled, never checking the `scaleMode`.
If `antialias` is true but `scaleMode` is `NEAREST`, then image smoothing will be disabled when drawing that texture.
However, the inverse isn't true. If `antialias` is false but `scaleMode` is `LINEAR`, image smoothing will still be disabled when drawing that texture.

My changes give `scaleMode` priority over `antialias`. In the above example, the logic is reduced to:
```
ctx.imageSmoothingEnabled = !frame.source.scaleMode;
```
In a case like this, we should be able to cut the `antialias` check out entirely since `antialias` already controls the default value of `TextureSource.scaleMode`.