### PR TITLE
Improve types for ArcdePhysics.closest

### DIFF
--- a/src/physics/arcade/ArcadePhysics.js
+++ b/src/physics/arcade/ArcadePhysics.js
@@ -417,10 +417,11 @@ var ArcadePhysics = new Class({
      * @method Phaser.Physics.Arcade.ArcadePhysics#closest
      * @since 3.0.0
      *
-     * @param {any} source - Any object with public `x` and `y` properties, such as a Game Object or Geometry object.
-     * @param {(Phaser.Physics.Arcade.Body[]|Phaser.Physics.Arcade.StaticBody[]|Phaser.GameObjects.GameObject[])} [targets] - The targets.
+     * @generic {Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody|Phaser.GameObjects.GameObject} Target
+     * @param {Phaser.Types.Math.Vector2Like} source - Any object with public `x` and `y` properties, such as a Game Object or Geometry object.
+     * @param {Target[]} [targets] - The targets.
      *
-     * @return {?(Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody|Phaser.GameObjects.GameObject)} The target closest to the given source point.
+     * @return {Target|null} The target closest to the given source point.
      */
     closest: function (source, targets)
     {


### PR DESCRIPTION
This uses generics so that the return type from `closest()` is narrowed to match whatever type you passed in for the targets.

I also clarified that the return type always includes `null` (which is what the implementation returns when it gets an empty list of targets).

And I clarified that the `source` needs to be `Vector2Like`. 

Resulting typescript diff:

```diff
--- a/types/phaser.d.ts
+++ b/types/phaser.d.ts
@@ -70565,7 +70565,7 @@ declare namespace Phaser {
                  * @param source Any object with public `x` and `y` properties, such as a Game Object or Geometry object.
                  * @param targets The targets.
                  */
-                closest(source: any, targets?: Phaser.Physics.Arcade.Body[] | Phaser.Physics.Arcade.StaticBody[] | Phaser.GameObjects.GameObject[]): Phaser.Physics.Arcade.Body | Phaser.Physics.Arcade.StaticBody | Phaser.GameObjects.GameObject;
+                closest<Target extends Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody|Phaser.GameObjects.GameObject>(source: Phaser.Types.Math.Vector2Like, targets?: Target[]): Target | null;

                 /**
                  * Finds the Body or Game Object farthest from a source point or object.
(END)
```

