### PR TITLE
fix: Wrap documentation

### DIFF
--- a/src/math/Wrap.js
+++ b/src/math/Wrap.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * Wrap the given `value` between `min` and `max.
+ * Wrap the given `value` between `min` and `max`.
  *
  * @function Phaser.Math.Wrap
  * @since 3.0.0


### PR DESCRIPTION
This PR: 
* Updates the Documentation


I just added the apostrophe at the end of the word to be as code.


(Sorry for this somewhat unnecessary PR, but I saw the "error" and thought it would be nice to help :))

