### PR TITLE
Minor patches to improve Tiled support

### DIFF
--- a/src/tilemaps/ParseToTilemap.js
+++ b/src/tilemaps/ParseToTilemap.js
@@ -32,10 +32,14 @@ var Tilemap = require('./Tilemap');
  * the tile data doesn't need to change then setting this value to `true` will help with memory
  * consumption. However if your map is small or you need to update the tiles dynamically, then leave
  * the default value set.
+ * @param {object} externalTilesets - In case Tiled JSON: An optional object mapping external
+ * tileset file names to their data. Specifically, an object whose OwnProperties (keys) match
+ * the "source" entries of the exported map's external tilesets,
+ * and whose values are parsed json objects acquired by exporting an external tileset.
  *
  * @return {Phaser.Tilemaps.Tilemap}
  */
-var ParseToTilemap = function (scene, key, tileWidth, tileHeight, width, height, data, insertNull)
+var ParseToTilemap = function (scene, key, tileWidth, tileHeight, width, height, data, insertNull, externalTilesets)
 {
     if (tileWidth === undefined) { tileWidth = 32; }
     if (tileHeight === undefined) { tileHeight = 32; }
@@ -60,7 +64,7 @@ var ParseToTilemap = function (scene, key, tileWidth, tileHeight, width, height,
         }
         else
         {
-            mapData = Parse(key, tilemapData.format, tilemapData.data, tileWidth, tileHeight, insertNull);
+            mapData = Parse(key, tilemapData.format, tilemapData.data, tileWidth, tileHeight, insertNull, externalTilesets);
         }
     }
 

--- a/src/tilemaps/TilemapCreator.js
+++ b/src/tilemaps/TilemapCreator.js
@@ -33,6 +33,7 @@ GameObjectCreator.register('tilemap', function (config)
         c.width,
         c.height,
         c.data,
-        c.insertNull
+        c.insertNull,
+        c.externalTilesets
     );
 });

--- a/src/tilemaps/mapdata/LayerData.js
+++ b/src/tilemaps/mapdata/LayerData.js
@@ -156,6 +156,15 @@ var LayerData = new Class({
         this.visible = GetFastValue(config, 'visible', true);
 
         /**
+         * The Tint Color assigned to this layer in Tiled.
+         *
+         * @name Phaser.Tilemaps.LayerData#tintColor
+         * @type {string | null}
+         * @since 3.0.0
+         */
+        this.tintColor = GetFastValue(config, 'tintColor', null);
+
+        /**
          * Layer specific properties (can be specified in Tiled)
          *
          * @name Phaser.Tilemaps.LayerData#properties

--- a/src/tilemaps/parsers/Parse.js
+++ b/src/tilemaps/parsers/Parse.js
@@ -32,10 +32,14 @@ var ParseWeltmeister = require('./impact/ParseWeltmeister');
  * the tile data doesn't need to change then setting this value to `true` will help with memory
  * consumption. However if your map is small or you need to update the tiles dynamically, then leave
  * the default value set.
+ * @param {object} externalTilesets - In case Tiled JSON: An optional object mapping external
+ * tileset file names to their data. Specifically, an object whose OwnProperties (keys) match
+ * the "source" entries of the exported map's external tilesets,
+ * and whose values are parsed json objects acquired by exporting an external tileset.
  *
  * @return {Phaser.Tilemaps.MapData} The created `MapData` object.
  */
-var Parse = function (name, mapFormat, data, tileWidth, tileHeight, insertNull)
+var Parse = function (name, mapFormat, data, tileWidth, tileHeight, insertNull, externalTilesets)
 {
     var newMap;
 
@@ -48,7 +52,7 @@ var Parse = function (name, mapFormat, data, tileWidth, tileHeight, insertNull)
             newMap = ParseCSV(name, data, tileWidth, tileHeight, insertNull);
             break;
         case (Formats.TILED_JSON):
-            newMap = ParseJSONTiled(name, data, insertNull);
+            newMap = ParseJSONTiled(name, data, insertNull, externalTilesets);
             break;
         case (Formats.WELTMEISTER):
             newMap = ParseWeltmeister(name, data, insertNull);

--- a/src/tilemaps/parsers/tiled/ParseImageCollection.js
+++ b/src/tilemaps/parsers/tiled/ParseImageCollection.js
@@ -1,0 +1,32 @@
+/**
+ * @author       Richard Davey <rich@photonstorm.com>
+ * @copyright    2022 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+var ImageCollection = require('../../ImageCollection');
+
+var ParseImageCollection = function (set)
+{
+    var collection = new ImageCollection(set.name, set.firstgid, set.tilewidth, set.tileheight, set.margin, set.spacing, set.properties);
+
+    var maxId = 0;
+
+    for (t = 0; t < set.tiles.length; t++)
+    {
+        tile = set.tiles[t];
+
+        var image = tile.image;
+        var tileId = parseInt(tile.id, 10);
+        var gid = set.firstgid + tileId;
+        collection.addImage(gid, image);
+
+        maxId = Math.max(tileId, maxId);
+    }
+
+    collection.maxId = maxId;
+    return collection;
+
+}
+
+module.exports = ParseImageCollection

--- a/src/tilemaps/parsers/tiled/ParseImageCollection.js
+++ b/src/tilemaps/parsers/tiled/ParseImageCollection.js
@@ -10,6 +10,7 @@ var ParseImageCollection = function (set)
 {
     var collection = new ImageCollection(set.name, set.firstgid, set.tilewidth, set.tileheight, set.margin, set.spacing, set.properties);
 
+    var t, tile;
     var maxId = 0;
 
     for (t = 0; t < set.tiles.length; t++)
@@ -27,6 +28,6 @@ var ParseImageCollection = function (set)
     collection.maxId = maxId;
     return collection;
 
-}
+};
 
-module.exports = ParseImageCollection
+module.exports = ParseImageCollection;

--- a/src/tilemaps/parsers/tiled/ParseJSONTiled.js
+++ b/src/tilemaps/parsers/tiled/ParseJSONTiled.js
@@ -29,10 +29,13 @@ var ParseTilesets = require('./ParseTilesets');
  * the tile data doesn't need to change then setting this value to `true` will help with memory
  * consumption. However if your map is small or you need to update the tiles dynamically, then leave
  * the default value set.
+ * @param {object} externalTilesets - An optional object mapping external tileset file names to their data.
+ * Specifically, an object whose OwnProperties (keys) match the "source" entries of the exported map's external tilesets,
+ * and whose values are parsed json objects acquired by exporting an external tileset.  
  *
  * @return {?Phaser.Tilemaps.MapData} The created MapData object, or `null` if the data can't be parsed.
  */
-var ParseJSONTiled = function (name, json, insertNull)
+var ParseJSONTiled = function (name, json, insertNull, externalTilesets)
 {
     //  Map data will consist of: layers, objects, images, tilesets, sizes
     var mapData = new MapData({
@@ -57,7 +60,7 @@ var ParseJSONTiled = function (name, json, insertNull)
     mapData.layers = ParseTileLayers(json, insertNull);
     mapData.images = ParseImageLayers(json);
 
-    var sets = ParseTilesets(json);
+    var sets = ParseTilesets(json, externalTilesets);
 
     mapData.tilesets = sets.tilesets;
     mapData.imageCollections = sets.imageCollections;

--- a/src/tilemaps/parsers/tiled/ParseTileLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseTileLayers.js
@@ -130,6 +130,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
+                tintColor: json.tintColor,
                 properties: GetFastValue(curl, 'properties', []),
                 orientation: FromOrientationString(json.orientation)
             });
@@ -208,6 +209,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
+                tintColor: json.tintColor,
                 properties: GetFastValue(curl, 'properties', []),
                 orientation: FromOrientationString(json.orientation)
             });

--- a/src/tilemaps/parsers/tiled/ParseTileLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseTileLayers.js
@@ -130,7 +130,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
-                tintColor: json.tintColor,
+                tintColor: curl.tintcolor,
                 properties: GetFastValue(curl, 'properties', []),
                 orientation: FromOrientationString(json.orientation)
             });
@@ -209,7 +209,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
-                tintColor: json.tintColor,
+                tintColor: curl.tintcolor,
                 properties: GetFastValue(curl, 'properties', []),
                 orientation: FromOrientationString(json.orientation)
             });

--- a/src/tilemaps/parsers/tiled/ParseTileset.js
+++ b/src/tilemaps/parsers/tiled/ParseTileset.js
@@ -1,0 +1,138 @@
+/**
+ * @author       Richard Davey <rich@photonstorm.com>
+ * @copyright    2022 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+var Tileset = require('../../Tileset');
+var ParseObject = require('./ParseObject');
+var ParseWangsets = require('./ParseWangsets');
+
+/**
+ * A full tileset definition.
+ *
+ * @function Phaser.Tilemaps.Parsers.Tiled.ParseTileset
+ * @since 3.x.x
+ *
+ * @param {object} set - The tileset data.
+ * @param {string | number} version - The version of Tiled that exported the tileset data.
+ *
+ * @return {Tileset} An object containing the tileset and image collection data.
+ */
+var ParseTileset = function (set, version) {
+
+    var tileSet = new Tileset(set.name, set.firstgid, set.tilewidth, set.tileheight, set.margin, set.spacing, undefined, undefined, set.tileoffset);
+
+    if (version > 1)
+    {
+        var datas = undefined;
+        var props = undefined;
+
+        if (Array.isArray(set.tiles))
+        {
+            datas = datas || {};
+            props = props || {};
+
+            // Tiled 1.2+
+            for (var t = 0; t < set.tiles.length; t++)
+            {
+                var tile = set.tiles[t];
+
+                //  Convert tileproperties.
+                if (tile.properties)
+                {
+                    var newPropData = {};
+
+                    tile.properties.forEach(function (propData)
+                    {
+                        newPropData[propData['name']] = propData['value'];
+                    });
+
+                    props[tile.id] = newPropData;
+                }
+
+                //  Convert objectgroup
+                if (tile.objectgroup)
+                {
+                    (datas[tile.id] || (datas[tile.id] = {})).objectgroup = tile.objectgroup;
+
+                    if (tile.objectgroup.objects)
+                    {
+                        var parsedObjects2 = tile.objectgroup.objects.map(function (obj)
+                        {
+                            return ParseObject(obj);
+                        });
+
+                        datas[tile.id].objectgroup.objects = parsedObjects2;
+                    }
+                }
+
+                // Copy animation data
+                if (tile.animation)
+                {
+                    (datas[tile.id] || (datas[tile.id] = {})).animation = tile.animation;
+                }
+
+                // Copy tile `type` field
+                // (see https://doc.mapeditor.org/en/latest/manual/custom-properties/#typed-tiles).
+                if (tile.type)
+                {
+                    (datas[tile.id] || (datas[tile.id] = {})).type = tile.type;
+                }
+            }
+        }
+
+        if (Array.isArray(set.wangsets))
+        {
+            datas = datas || {};
+            props = props || {};
+
+            ParseWangsets(set.wangsets, datas);
+        }
+
+        if (datas) // Implies also props is set.
+        {
+            tileSet.tileData = datas;
+            tileSet.tileProperties = props;
+        }
+    }
+    else
+    {
+        // Tiled 1
+
+        // Properties stored per-tile in object with string indexes starting at "0"
+        if (set.tileproperties)
+        {
+            tileSet.tileProperties = set.tileproperties;
+        }
+
+        // Object & terrain shapes stored per-tile in object with string indexes starting at "0"
+        if (set.tiles)
+        {
+            tileSet.tileData = set.tiles;
+
+            // Parse the objects into Phaser format to match handling of other Tiled objects
+            for (let stringID in tileSet.tileData)
+            {
+                var objectGroup = tileSet.tileData[stringID].objectgroup;
+
+                if (objectGroup && objectGroup.objects)
+                {
+                    var parsedObjects1 = objectGroup.objects.map(function (obj)
+                    {
+                        return ParseObject(obj);
+                    });
+
+                    tileSet.tileData[stringID].objectgroup.objects = parsedObjects1;
+                }
+            }
+        }
+    }
+
+    // For a normal sliced tileset the row/count/size information is computed when updated.
+    // This is done (again) after the image is set.
+    tileSet.updateTileData(set.imagewidth, set.imageheight);
+    return tileSet;
+}
+
+module.exports = ParseTileset;

--- a/src/tilemaps/parsers/tiled/ParseTileset.js
+++ b/src/tilemaps/parsers/tiled/ParseTileset.js
@@ -19,8 +19,8 @@ var ParseWangsets = require('./ParseWangsets');
  *
  * @return {Tileset} An object containing the tileset and image collection data.
  */
-var ParseTileset = function (set, version) {
-
+var ParseTileset = function (set, version)
+{
     var tileSet = new Tileset(set.name, set.firstgid, set.tilewidth, set.tileheight, set.margin, set.spacing, undefined, undefined, set.tileoffset);
 
     if (version > 1)
@@ -109,10 +109,11 @@ var ParseTileset = function (set, version) {
         // Object & terrain shapes stored per-tile in object with string indexes starting at "0"
         if (set.tiles)
         {
+            var stringID;
             tileSet.tileData = set.tiles;
 
             // Parse the objects into Phaser format to match handling of other Tiled objects
-            for (let stringID in tileSet.tileData)
+            for (stringID in tileSet.tileData)
             {
                 var objectGroup = tileSet.tileData[stringID].objectgroup;
 
@@ -133,6 +134,6 @@ var ParseTileset = function (set, version) {
     // This is done (again) after the image is set.
     tileSet.updateTileData(set.imagewidth, set.imageheight);
     return tileSet;
-}
+};
 
 module.exports = ParseTileset;

--- a/src/tilemaps/parsers/tiled/ParseTilesets.js
+++ b/src/tilemaps/parsers/tiled/ParseTilesets.js
@@ -4,10 +4,8 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var Tileset = require('../../Tileset');
-var ImageCollection = require('../../ImageCollection');
-var ParseObject = require('./ParseObject');
-var ParseWangsets = require('./ParseWangsets');
+var ParseTileset = require('./ParseTileset');
+var ParseImageCollection = require('./ParseImageCollection');
 
 /**
  * Tilesets and Image Collections.
@@ -16,15 +14,17 @@ var ParseWangsets = require('./ParseWangsets');
  * @since 3.0.0
  *
  * @param {object} json - The Tiled JSON data.
+ * @param {object} externalTilesets - An optional object mapping external tileset file names to their data.
+ * Specifically, an object whose OwnProperties (keys) match the "source" entries of the exported map's external tilesets,
+ * and whose values are parsed json objects acquired by exporting an external tileset.  
  *
  * @return {object} An object containing the tileset and image collection data.
  */
-var ParseTilesets = function (json)
+var ParseTilesets = function (json, externalTilesets)
 {
     var tilesets = [];
     var imageCollections = [];
     var lastSet = null;
-    var stringID;
 
     for (var i = 0; i < json.tilesets.length; i++)
     {
@@ -33,144 +33,36 @@ var ParseTilesets = function (json)
 
         if (set.source)
         {
-            console.warn('External tilesets unsupported. Use Embed Tileset and re-export');
-        }
-        else if (set.image)
-        {
-            var newSet = new Tileset(set.name, set.firstgid, set.tilewidth, set.tileheight, set.margin, set.spacing, undefined, undefined, set.tileoffset);
+            if( externalTilesets !== undefined && set.source in externalTilesets ) {
+                console.info('Found external tileset', set.source);
 
-            if (json.version > 1)
-            {
-                var datas = undefined;
-                var props = undefined;
+                // Clone the external tileset config file, and set the firstgid property
+                var externalSet = Object.assign({firstgid: set.firstgid}, externalTilesets[set.source]);
 
-                if (Array.isArray(set.tiles))
+                if( externalSet.image )
                 {
-                    datas = datas || {};
-                    props = props || {};
-
-                    // Tiled 1.2+
-                    for (var t = 0; t < set.tiles.length; t++)
-                    {
-                        var tile = set.tiles[t];
-
-                        //  Convert tileproperties.
-                        if (tile.properties)
-                        {
-                            var newPropData = {};
-
-                            tile.properties.forEach(function (propData)
-                            {
-                                newPropData[propData['name']] = propData['value'];
-                            });
-
-                            props[tile.id] = newPropData;
-                        }
-
-                        //  Convert objectgroup
-                        if (tile.objectgroup)
-                        {
-                            (datas[tile.id] || (datas[tile.id] = {})).objectgroup = tile.objectgroup;
-
-                            if (tile.objectgroup.objects)
-                            {
-                                var parsedObjects2 = tile.objectgroup.objects.map(function (obj)
-                                {
-                                    return ParseObject(obj);
-                                });
-
-                                datas[tile.id].objectgroup.objects = parsedObjects2;
-                            }
-                        }
-
-                        // Copy animation data
-                        if (tile.animation)
-                        {
-                            (datas[tile.id] || (datas[tile.id] = {})).animation = tile.animation;
-                        }
-
-                        // Copy tile `type` field
-                        // (see https://doc.mapeditor.org/en/latest/manual/custom-properties/#typed-tiles).
-                        if (tile.type)
-                        {
-                            (datas[tile.id] || (datas[tile.id] = {})).type = tile.type;
-                        }
-                    }
+                    var newSet = ParseTileset(externalSet, externalSet.version);
+                    tilesets.push(newSet);
                 }
-
-                if (Array.isArray(set.wangsets))
+                else
                 {
-                    datas = datas || {};
-                    props = props || {};
-
-                    ParseWangsets(set.wangsets, datas);
-                }
-
-                if (datas) // Implies also props is set.
-                {
-                    newSet.tileData = datas;
-                    newSet.tileProperties = props;
+                    var newCollection = ParseImageCollection(externalSet);
+                    imageCollections.push(newCollection);
                 }
             }
             else
             {
-                // Tiled 1
-
-                // Properties stored per-tile in object with string indexes starting at "0"
-                if (set.tileproperties)
-                {
-                    newSet.tileProperties = set.tileproperties;
-                }
-
-                // Object & terrain shapes stored per-tile in object with string indexes starting at "0"
-                if (set.tiles)
-                {
-                    newSet.tileData = set.tiles;
-
-                    // Parse the objects into Phaser format to match handling of other Tiled objects
-                    for (stringID in newSet.tileData)
-                    {
-                        var objectGroup = newSet.tileData[stringID].objectgroup;
-
-                        if (objectGroup && objectGroup.objects)
-                        {
-                            var parsedObjects1 = objectGroup.objects.map(function (obj)
-                            {
-                                return ParseObject(obj);
-                            });
-
-                            newSet.tileData[stringID].objectgroup.objects = parsedObjects1;
-                        }
-                    }
-                }
+                console.error(`Map uses external tileset with source "${set.source}" which was not given.`);
             }
-
-            // For a normal sliced tileset the row/count/size information is computed when updated.
-            // This is done (again) after the image is set.
-            newSet.updateTileData(set.imagewidth, set.imageheight);
-
+        }
+        else if (set.image)
+        {
+            var newSet = ParseTileset(set, json.version);
             tilesets.push(newSet);
         }
         else
         {
-            var newCollection = new ImageCollection(set.name, set.firstgid, set.tilewidth, set.tileheight, set.margin, set.spacing, set.properties);
-
-            var maxId = 0;
-
-            for (t = 0; t < set.tiles.length; t++)
-            {
-                tile = set.tiles[t];
-
-                var image = tile.image;
-                var tileId = parseInt(tile.id, 10);
-                var gid = set.firstgid + tileId;
-                newCollection.addImage(gid, image);
-
-                maxId = Math.max(tileId, maxId);
-            }
-
-            newCollection.maxId = maxId;
-
+            var newCollection = ParseImageCollection(set);
             imageCollections.push(newCollection);
         }
 

--- a/src/tilemaps/parsers/tiled/ParseTilesets.js
+++ b/src/tilemaps/parsers/tiled/ParseTilesets.js
@@ -25,6 +25,7 @@ var ParseTilesets = function (json, externalTilesets)
     var tilesets = [];
     var imageCollections = [];
     var lastSet = null;
+    var newSet, newCollection;
 
     for (var i = 0; i < json.tilesets.length; i++)
     {
@@ -33,36 +34,35 @@ var ParseTilesets = function (json, externalTilesets)
 
         if (set.source)
         {
-            if( externalTilesets !== undefined && set.source in externalTilesets ) {
-                console.info('Found external tileset', set.source);
+            if (externalTilesets !== undefined && externalTilesets[set.source])
+            {
+                var externalSet = externalTilesets[set.source];
+                externalSet.firstgid = set.firstgid;
 
-                // Clone the external tileset config file, and set the firstgid property
-                var externalSet = Object.assign({firstgid: set.firstgid}, externalTilesets[set.source]);
-
-                if( externalSet.image )
+                if (externalSet.image)
                 {
-                    var newSet = ParseTileset(externalSet, externalSet.version);
+                    newSet = ParseTileset(externalSet, externalSet.version);
                     tilesets.push(newSet);
                 }
                 else
                 {
-                    var newCollection = ParseImageCollection(externalSet);
+                    newCollection = ParseImageCollection(externalSet);
                     imageCollections.push(newCollection);
                 }
             }
             else
             {
-                console.error(`Map uses external tileset with source "${set.source}" which was not given.`);
+                console.warn('Map uses external tileset with source "' + set.source + '" which was not given.');
             }
         }
         else if (set.image)
         {
-            var newSet = ParseTileset(set, json.version);
+            newSet = ParseTileset(set, json.version);
             tilesets.push(newSet);
         }
         else
         {
-            var newCollection = ParseImageCollection(set);
+            newCollection = ParseImageCollection(set);
             imageCollections.push(newCollection);
         }
 

--- a/src/tilemaps/parsers/tiled/index.js
+++ b/src/tilemaps/parsers/tiled/index.js
@@ -22,6 +22,6 @@ module.exports = {
     ParseTileLayers: require('./ParseTileLayers'),
     ParseTilesets: require('./ParseTilesets'),
     ParseTileset: require('./ParseTileset'),
-    ParseImageCollection: require('./ParseImageCollection'),
+    ParseImageCollection: require('./ParseImageCollection')
 
 };

--- a/src/tilemaps/parsers/tiled/index.js
+++ b/src/tilemaps/parsers/tiled/index.js
@@ -20,6 +20,8 @@ module.exports = {
     ParseObject: require('./ParseObject'),
     ParseObjectLayers: require('./ParseObjectLayers'),
     ParseTileLayers: require('./ParseTileLayers'),
-    ParseTilesets: require('./ParseTilesets')
+    ParseTilesets: require('./ParseTilesets'),
+    ParseTileset: require('./ParseTileset'),
+    ParseImageCollection: require('./ParseImageCollection'),
 
 };

--- a/src/tilemaps/typedefs/TilemapConfig.js
+++ b/src/tilemaps/typedefs/TilemapConfig.js
@@ -14,4 +14,8 @@
  * map and the tile data doesn't need to change then setting this value to `true` will help with
  * memory consumption. However if your map is small or you need to update the tiles dynamically,
  * then leave the default value set.
+ * @property {object} [externalTilesets=undefined] - In case Tiled JSON: An optional object mapping external
+ * tileset file names to their data. Specifically, an object whose OwnProperties (keys) match
+ * the "source" entries of the exported map's external tilesets,
+ * and whose values are parsed json objects acquired by exporting an external tileset.
  */


### PR DESCRIPTION
This PR adds two new features:

1. LayerData objects now have a tintColor property, set in case they're parsed from a Tiled JSON file.
(Given the recently added TileLayer.setTint() this seemed appropriate to have.)

2. Parsing maps from Tiled now allows an optional `externalTilesets` argument which may be used to specify external tilesets.

Example usage:

```ts
load() {
    this.json.load('my_tileset', 'tilemaps/tilesets/my_tileset.json')
    this.load.tilemapTiledJSON('my_map', `tilemaps/my_map.json`)
}

create() {
    var myTileset = this.cache.json.get('my_tileset')

    // You have to figure out which key values you need here by looking through your "my_map.json" file...
    var externalTilesets = {
        'tilesets/my_tileset.tsx': my_tileset
    }
    var map = this.make.tilemap({ key: 'my_map', externalTilesets: externalTilesets })
}
```

### Caveat

It's a rough solution, and awkward to use since you have to personally load in your tilesets and assign them matching keys according to their "origin".
That said, it solves my need, and I figure it's a bit better than not supporting external tilesets at all.
It's also my first time contributing, I tried my best to match the style of what was there, but it's possible I've made some blunders.

### Motivation

I was totally fine using embedded tilesets for a decent while, but I've found that needing to re-export every map to propagate changes to tilesets (I use a lot of tile properties) got very bothersome. Moreover I figured this would end up saving up to 10MB of repeated data from all my tilemap JSON files.