### PR TITLE
Add texture add/remove key events

### DIFF
--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -220,6 +220,7 @@ var TextureManager = new Class({
             key.destroy();
 
             this.emit(Events.REMOVE, key.key);
+            this.emit(Events.REMOVE_KEY + key.key);
         }
 
         return this;
@@ -283,7 +284,7 @@ var TextureManager = new Class({
                 Parser.Image(texture, 0);
 
                 _this.emit(Events.ADD, key, texture);
-
+                _this.emit(Events.ADD_KEY + key, texture);
                 _this.emit(Events.LOAD, key, texture);
             };
 
@@ -384,6 +385,7 @@ var TextureManager = new Class({
             }
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -424,6 +426,7 @@ var TextureManager = new Class({
             texture.add('__BASE', 0, 0, 0, width, height);
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -474,6 +477,7 @@ var TextureManager = new Class({
             }
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -503,6 +507,7 @@ var TextureManager = new Class({
             texture.add('__BASE', 0, 0, 0, renderTexture.width, renderTexture.height);
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -630,6 +635,7 @@ var TextureManager = new Class({
             this.list[key] = texture;
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -710,6 +716,7 @@ var TextureManager = new Class({
             }
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -757,6 +764,7 @@ var TextureManager = new Class({
             }
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -793,6 +801,7 @@ var TextureManager = new Class({
             }
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -829,6 +838,7 @@ var TextureManager = new Class({
             }
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -864,6 +874,7 @@ var TextureManager = new Class({
             Parser.SpriteSheet(texture, 0, 0, 0, width, height, config);
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
         }
 
         return texture;
@@ -917,6 +928,7 @@ var TextureManager = new Class({
             }
 
             this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD_KEY + key, texture);
 
             return texture;
         }

--- a/src/textures/events/ADD_KEY_EVENT.js
+++ b/src/textures/events/ADD_KEY_EVENT.js
@@ -1,0 +1,19 @@
+/**
+ * @author       samme
+ * @copyright    2022 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+/**
+ * The Texture Add Key Event.
+ *
+ * This event is dispatched by the Texture Manager when a texture with the given key is added to it.
+ *
+ * Listen to this event from within a Scene using: `this.textures.on('addtexture-key', listener)`.
+ *
+ * @event Phaser.Textures.Events#ADD_KEY
+ * @since 3.60.0
+ *
+ * @param {Phaser.Textures.Texture} texture - A reference to the Texture that was added to the Texture Manager.
+ */
+module.exports = 'addtexture-';

--- a/src/textures/events/REMOVE_KEY_EVENT.js
+++ b/src/textures/events/REMOVE_KEY_EVENT.js
@@ -1,0 +1,20 @@
+/**
+ * @author       samme
+ * @copyright    2022 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+/**
+ * The Texture Remove Key Event.
+ *
+ * This event is dispatched by the Texture Manager when a texture with the given key is removed from it.
+ *
+ * Listen to this event from within a Scene using: `this.textures.on('removetexture-key', listener)`.
+ *
+ * If you have any Game Objects still using the removed texture, they will start throwing
+ * errors the next time they try to render. Be sure to clear all use of the texture in this event handler.
+ *
+ * @event Phaser.Textures.Events#REMOVE_KEY
+ * @since 3.60.0
+ */
+module.exports = 'removetexture-';

--- a/src/textures/events/index.js
+++ b/src/textures/events/index.js
@@ -11,9 +11,11 @@
 module.exports = {
 
     ADD: require('./ADD_EVENT'),
+    ADD_KEY: require('./ADD_KEY_EVENT'),
     ERROR: require('./ERROR_EVENT'),
     LOAD: require('./LOAD_EVENT'),
     READY: require('./READY_EVENT'),
-    REMOVE: require('./REMOVE_EVENT')
+    REMOVE: require('./REMOVE_EVENT'),
+    REMOVE_KEY: require('./REMOVE_KEY_EVENT'),
 
 };


### PR DESCRIPTION
This PR

* Adds a new feature (#5973)

This makes using `once()` for a specific texture much easier.

- Phaser.Textures.Events.ADD_KEY
- Phaser.Textures.Events.REMOVE_KEY

