### PR TITLE
Exclude __WHITE in getTextureKeys()

### DIFF
--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -1038,7 +1038,7 @@ var TextureManager = new Class({
 
     /**
      * Returns an array with all of the keys of all Textures in this Texture Manager.
-     * The output array will exclude the `__DEFAULT` and `__MISSING` keys.
+     * The output array will exclude the `__DEFAULT`, `__MISSING`, and `__WHITE` keys.
      *
      * @method Phaser.Textures.TextureManager#getTextureKeys
      * @since 3.0.0
@@ -1051,7 +1051,7 @@ var TextureManager = new Class({
 
         for (var key in this.list)
         {
-            if (key !== '__DEFAULT' && key !== '__MISSING')
+            if (key !== '__DEFAULT' && key !== '__MISSING' && key !== '__WHITE')
             {
                 output.push(key);
             }


### PR DESCRIPTION
This PR

* Fixes a bug

[getTextureKeys()](https://newdocs.phaser.io/docs/3.55.2/Phaser.Textures.TextureManager#getTextureKeys) would include `'__WHITE'`, which didn't seem right.

