### PR TITLE
Destroy Arcade Physics debug graphic with world

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -2440,6 +2440,12 @@ var World = new Class({
         this.shutdown();
 
         this.scene = null;
+
+        if (this.debugGraphic)
+        {
+            this.debugGraphic.destroy();
+            this.debugGraphic = null;
+        }
     }
 
 });


### PR DESCRIPTION
This PR

* Fixes a bug

Phaser.Physics.Arcade.World would create a debug graphic but not destroy it. Ordinarily this isn't a problem, but if you do, e.g.,

```
this.physics.shutdown();
this.physics.start();
```

while the scene is running then the graphics will stack up.
