### PR TITLE
Fix wrong alpha in snapshot pixel

### DIFF
--- a/src/renderer/snapshot/CanvasSnapshot.js
+++ b/src/renderer/snapshot/CanvasSnapshot.js
@@ -37,7 +37,7 @@ var CanvasSnapshot = function (canvas, config)
         var imageData = context.getImageData(x, y, 1, 1);
         var data = imageData.data;
 
-        callback.call(null, new Color(data[0], data[1], data[2], data[3] / 255));
+        callback.call(null, new Color(data[0], data[1], data[2], data[3]));
     }
     else if (x !== 0 || y !== 0 || width !== canvas.width || height !== canvas.height)
     {

--- a/src/renderer/snapshot/WebGLSnapshot.js
+++ b/src/renderer/snapshot/WebGLSnapshot.js
@@ -45,7 +45,7 @@ var WebGLSnapshot = function (sourceContext, config)
 
         gl.readPixels(x, destY, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
 
-        callback.call(null, new Color(pixel[0], pixel[1], pixel[2], pixel[3] / 255));
+        callback.call(null, new Color(pixel[0], pixel[1], pixel[2], pixel[3]));
     }
     else
     {


### PR DESCRIPTION
This PR

* Fixes a bug

The renderer and Render Texture `snapshotPixel()` methods would give [incorrect pixel `alpha` and `alphaGL` values](https://phaser.discourse.group/t/get-pixel-of-rendertexture/7442/20).

There was unnecessary division.

