### PR TITLE
Show WebGL error code

### DIFF
--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -2178,7 +2178,7 @@ var WebGLRenderer = new Class({
                 36061: 'Framebuffer Unsupported'
             };
 
-            throw new Error('Framebuffer status: ' + errors[complete]);
+            throw new Error('Framebuffer status: ' + (errors[complete] || complete));
         }
 
         framebuffer.renderTexture = renderTexture;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Show the webgl error code value if it is not present within the object map. Currently it just prints "Framebuffer status: undefined", now it will print "Framebuffer status: 69420" etc