### PR TITLE
Fix function Graphics -> strokeRoundedRect

### DIFF
--- a/src/gameobjects/graphics/Graphics.js
+++ b/src/gameobjects/graphics/Graphics.js
@@ -710,6 +710,8 @@ var Graphics = new Class({
         var tr = radius;
         var bl = radius;
         var br = radius;
+        
+        var maxRadius = Math.min(width, height) / 2;
 
         if (typeof radius !== 'number')
         {
@@ -718,7 +720,12 @@ var Graphics = new Class({
             bl = GetFastValue(radius, 'bl', 20);
             br = GetFastValue(radius, 'br', 20);
         }
-
+        
+        tl = Math.min(tl, maxRadius);
+        tr = Math.min(tr, maxRadius);
+        bl = Math.min(bl, maxRadius);
+        br = Math.min(br, maxRadius);
+        
         this.beginPath();
         this.moveTo(x + tl, y);
         this.lineTo(x + width - tr, y);


### PR DESCRIPTION
This PR

* Fixes a bug


If you call the strokeRoundedRect function in Graphics, and pass to arguments a radius greater than half of the smaller side of the rectangle, then the library will draw a completely different figure.

Adding a maximum radius to the code fixes this bug.

Before:
![image](https://user-images.githubusercontent.com/51059739/188273938-966fea1a-ad12-458e-9a60-e941b5f4bf14.png)

After (Desired result):
![image](https://user-images.githubusercontent.com/51059739/188273950-28ddc6ba-6a0b-4f21-8e9d-ceb739e9d206.png)
