### PR TITLE
Fix: BitmapText width calculation

### DIFF
--- a/src/gameobjects/bitmaptext/GetBitmapTextSize.js
+++ b/src/gameobjects/bitmaptext/GetBitmapTextSize.js
@@ -172,7 +172,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
                 }
 
                 current.word = current.word.concat(text[i]);
-                current.w += glyph.xOffset + glyph.xAdvance + ((glyphKerningOffset !== undefined) ? glyphKerningOffset : 0);
+                current.w += glyph.xOffset + glyph.width + ((glyphKerningOffset !== undefined) ? glyphKerningOffset : 0);
             }
 
             xAdvance += glyph.xAdvance + letterSpacing;
@@ -339,7 +339,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
             by = y;
         }
 
-        var gw = x + glyph.xAdvance;
+        var gw = x + glyph.width;
         var gh = y + lineHeight;
 
         if (bw < gw)
@@ -352,7 +352,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
             bh = gh;
         }
 
-        var charWidth = glyph.xOffset + glyph.xAdvance + ((kerningOffset !== undefined) ? kerningOffset : 0);
+        var charWidth = glyph.xOffset + glyph.width + ((kerningOffset !== undefined) ? kerningOffset : 0);
 
         if (charCode === wordWrapCharCode)
         {


### PR DESCRIPTION
The BitmapText width should be calculated using the actual glyphs' `width`, not their `xAdvance` property.

This PR

* Fixes a bug

The `xAdvance` property defines how distant in horizontal space the next glyph should be drawn. It does not necessarily coincide with the glyph `width` property.
Consider for example a glyph with a shadow on the right side. The glyph should advance by its total width minus the right shadow offset. The total bitmaptext however should be calculated taking into account the shadow as well.