### PR TITLE
Fix delta history array length

### DIFF
--- a/src/core/TimeStep.js
+++ b/src/core/TimeStep.js
@@ -581,7 +581,7 @@ var TimeStep = new Class({
         //  this stops the array growing beyond the size of deltaSmoothingMax
         this.deltaIndex++;
 
-        if (this.deltaIndex > max)
+        if (this.deltaIndex >= max)
         {
             this.deltaIndex = 0;
         }


### PR DESCRIPTION
This PR
- Fixes a bug

Describe the changes below:

The length of the `deltaHistory` array in `TimeStep` is meant to be `deltaSmoothingMax` (e.g. every `for` loop iterating over this array does `deltaSmoothingMax` iterations), but `deltaIndex` is only reset to `0` once it reaches `deltaSmoothingMax`, which effectively extends the array's length to `deltaSmoothingMax + 1`

For example, with `deltaSmoothingMax` set to the default value of 10, you'll find that the `deltaHistory` array eventually contains `11` elements instead of `10`