### PR TITLE
Improve stable sort performance

### DIFF
--- a/src/core/Config.js
+++ b/src/core/Config.js
@@ -593,6 +593,12 @@ var Config = new Class({
                 this.renderType = CONST.CANVAS;
             }
         }
+
+
+        /**
+         * @const {boolean} Phaser.Core.Config#es2019 - Use native ES2019 features
+         */
+        this.es2019 = GetValue(config, 'es2019', false);
     }
 
 });

--- a/src/core/typedefs/GameConfig.js
+++ b/src/core/typedefs/GameConfig.js
@@ -55,4 +55,5 @@
  * @property {Phaser.Scale.CenterType} [autoCenter=Phaser.Scale.Center.NO_CENTER] - Automatically center the canvas within the parent?
  * @property {number} [resizeInterval=500] - How many ms should elapse before checking if the browser size has changed?
  * @property {?(HTMLElement|string)} [fullscreenTarget] - The DOM element that will be sent into full screen mode, or its `id`. If undefined Phaser will create its own div and insert the canvas into it when entering fullscreen mode.
+ * @property {boolean} [es2019=false] - Use es2019 features
  */

--- a/src/gameobjects/DisplayList.js
+++ b/src/gameobjects/DisplayList.js
@@ -80,6 +80,8 @@ var DisplayList = new Class({
 
         this.events.once(SceneEvents.BOOT, this.boot, this);
         this.events.on(SceneEvents.START, this.start, this);
+
+        this.gameConfig = scene.sys.game.config;
     },
 
     /**
@@ -187,7 +189,7 @@ var DisplayList = new Class({
     {
         if (this.sortChildrenFlag)
         {
-            StableSort(this.list, this.sortByDepth);
+            StableSort(this.list, this.sortByDepth, this.gameConfig.es2019);
 
             this.sortChildrenFlag = false;
         }

--- a/src/utils/array/StableSort.js
+++ b/src/utils/array/StableSort.js
@@ -21,6 +21,123 @@ function Compare (a, b)
 }
 
 /**
+ * Process the array contents.
+ *
+ * @ignore
+ *
+ * @param {array} array - The array to process.
+ * @param {function} compare - The comparison function.
+ *
+ * @return {array} - The processed array.
+ */
+function Process (array, compare)
+{
+    // Short-circuit when there's nothing to sort.
+    var len = array.length;
+
+    if (len <= 1)
+    {
+        return array;
+    }
+
+    // Rather than dividing input, simply iterate chunks of 1, 2, 4, 8, etc.
+    // Chunks are the size of the left or right hand in merge sort.
+    // Stop when the left-hand covers all of the array.
+    var buffer = new Array(len);
+
+    for (var chk = 1; chk < len; chk *= 2)
+    {
+        RunPass(array, compare, chk, buffer);
+
+        var tmp = array;
+
+        array = buffer;
+
+        buffer = tmp;
+    }
+
+    return array;
+}
+
+/**
+ * Run a single pass with the given chunk size.
+ *
+ * @ignore
+ *
+ * @param {array} arr - The array to run the pass on.
+ * @param {function} comp - The comparison function.
+ * @param {number} chk - The number of iterations.
+ * @param {array} result - The array to store the result in.
+ */
+function RunPass (arr, comp, chk, result)
+{
+    var len = arr.length;
+    var i = 0;
+
+    // Step size / double chunk size.
+    var dbl = chk * 2;
+
+    // Bounds of the left and right chunks.
+    var l, r, e;
+
+    // Iterators over the left and right chunk.
+    var li, ri;
+
+    // Iterate over pairs of chunks.
+    for (l = 0; l < len; l += dbl)
+    {
+        r = l + chk;
+        e = r + chk;
+
+        if (r > len)
+        {
+            r = len;
+        }
+
+        if (e > len)
+        {
+            e = len;
+        }
+
+        // Iterate both chunks in parallel.
+        li = l;
+        ri = r;
+
+        while (true)
+        {
+            // Compare the chunks.
+            if (li < r && ri < e)
+            {
+                // This works for a regular `sort()` compatible comparator,
+                // but also for a simple comparator like: `a > b`
+                if (comp(arr[li], arr[ri]) <= 0)
+                {
+                    result[i++] = arr[li++];
+                }
+                else
+                {
+                    result[i++] = arr[ri++];
+                }
+            }
+            else if (li < r)
+            {
+                // Nothing to compare, just flush what's left.
+                result[i++] = arr[li++];
+            }
+            else if (ri < e)
+            {
+                result[i++] = arr[ri++];
+            }
+            else
+            {
+                // Both iterators are at the chunk ends.
+                break;
+            }
+        }
+    }
+}
+
+/**
  * An in-place stable array sort, because `Array#sort()` is not guaranteed stable.
  *
  * This is an implementation of merge sort, without recursion.
@@ -39,7 +156,15 @@ var StableSort = function (array, compare)
 {
     if (compare === undefined) { compare = Compare; }
 
-    return array.sort(compare);
+    var result = Process(array, compare);
+
+    // This simply copies back if the result isn't in the original array, which happens on an odd number of passes.
+    if (result !== array)
+    {
+        RunPass(result, null, array.length, array);
+    }
+
+    return array;
 };
 
 module.exports = StableSort;

--- a/src/utils/array/StableSort.js
+++ b/src/utils/array/StableSort.js
@@ -149,12 +149,17 @@ function RunPass (arr, comp, chk, result)
  *
  * @param {array} array - The input array to be sorted.
  * @param {function} [compare] - The comparison function.
+ * @param {boolean} es2019 - Use the native `Array.prototype.sort()` if available.
  *
  * @return {array} The sorted result.
  */
-var StableSort = function (array, compare)
+var StableSort = function (array, compare, es2019)
 {
     if (compare === undefined) { compare = Compare; }
+
+    if(es2019){
+        return array.sort(compare);
+    }
 
     var result = Process(array, compare);
 

--- a/src/utils/array/StableSort.js
+++ b/src/utils/array/StableSort.js
@@ -21,123 +21,6 @@ function Compare (a, b)
 }
 
 /**
- * Process the array contents.
- *
- * @ignore
- *
- * @param {array} array - The array to process.
- * @param {function} compare - The comparison function.
- *
- * @return {array} - The processed array.
- */
-function Process (array, compare)
-{
-    // Short-circuit when there's nothing to sort.
-    var len = array.length;
-
-    if (len <= 1)
-    {
-        return array;
-    }
-
-    // Rather than dividing input, simply iterate chunks of 1, 2, 4, 8, etc.
-    // Chunks are the size of the left or right hand in merge sort.
-    // Stop when the left-hand covers all of the array.
-    var buffer = new Array(len);
-
-    for (var chk = 1; chk < len; chk *= 2)
-    {
-        RunPass(array, compare, chk, buffer);
-
-        var tmp = array;
-
-        array = buffer;
-
-        buffer = tmp;
-    }
-
-    return array;
-}
-
-/**
- * Run a single pass with the given chunk size.
- *
- * @ignore
- *
- * @param {array} arr - The array to run the pass on.
- * @param {function} comp - The comparison function.
- * @param {number} chk - The number of iterations.
- * @param {array} result - The array to store the result in.
- */
-function RunPass (arr, comp, chk, result)
-{
-    var len = arr.length;
-    var i = 0;
-
-    // Step size / double chunk size.
-    var dbl = chk * 2;
-
-    // Bounds of the left and right chunks.
-    var l, r, e;
-
-    // Iterators over the left and right chunk.
-    var li, ri;
-
-    // Iterate over pairs of chunks.
-    for (l = 0; l < len; l += dbl)
-    {
-        r = l + chk;
-        e = r + chk;
-
-        if (r > len)
-        {
-            r = len;
-        }
-
-        if (e > len)
-        {
-            e = len;
-        }
-
-        // Iterate both chunks in parallel.
-        li = l;
-        ri = r;
-
-        while (true)
-        {
-            // Compare the chunks.
-            if (li < r && ri < e)
-            {
-                // This works for a regular `sort()` compatible comparator,
-                // but also for a simple comparator like: `a > b`
-                if (comp(arr[li], arr[ri]) <= 0)
-                {
-                    result[i++] = arr[li++];
-                }
-                else
-                {
-                    result[i++] = arr[ri++];
-                }
-            }
-            else if (li < r)
-            {
-                // Nothing to compare, just flush what's left.
-                result[i++] = arr[li++];
-            }
-            else if (ri < e)
-            {
-                result[i++] = arr[ri++];
-            }
-            else
-            {
-                // Both iterators are at the chunk ends.
-                break;
-            }
-        }
-    }
-}
-
-/**
  * An in-place stable array sort, because `Array#sort()` is not guaranteed stable.
  *
  * This is an implementation of merge sort, without recursion.
@@ -156,15 +39,7 @@ var StableSort = function (array, compare)
 {
     if (compare === undefined) { compare = Compare; }
 
-    var result = Process(array, compare);
-
-    // This simply copies back if the result isn't in the original array, which happens on an odd number of passes.
-    if (result !== array)
-    {
-        RunPass(result, null, array.length, array);
-    }
-
-    return array;
+    return array.sort(compare);
 };
 
 module.exports = StableSort;


### PR DESCRIPTION
This PR

* Improves performance

[Issue created here](https://github.com/photonstorm/phaser/pull/6216). I'm not sure if this is ok solution, but simple array.sort could be used

