### PR TITLE
Fix function ParseJSONTiled

### DIFF
--- a/src/tilemaps/parsers/tiled/ParseJSONTiled.js
+++ b/src/tilemaps/parsers/tiled/ParseJSONTiled.js
@@ -7,6 +7,7 @@
 var AssignTileProperties = require('./AssignTileProperties');
 var BuildTilesetIndex = require('./BuildTilesetIndex');
 var CONST = require('../../const/ORIENTATION_CONST');
+var DeepCopy = require("../../../utils/object/DeepCopy");
 var Formats = require('../../Formats');
 var FromOrientationString = require('../FromOrientationString');
 var MapData = require('../../mapdata/MapData');
@@ -34,35 +35,37 @@ var ParseTilesets = require('./ParseTilesets');
  */
 var ParseJSONTiled = function (name, json, insertNull)
 {
+    var copyJsonData = DeepCopy(json);
+    
     //  Map data will consist of: layers, objects, images, tilesets, sizes
     var mapData = new MapData({
-        width: json.width,
-        height: json.height,
+        width: copyJsonData.width,
+        height: copyJsonData.height,
         name: name,
-        tileWidth: json.tilewidth,
-        tileHeight: json.tileheight,
-        orientation: FromOrientationString(json.orientation),
+        tileWidth: copyJsonData.tilewidth,
+        tileHeight: copyJsonData.tileheight,
+        orientation: FromOrientationString(copyJsonData.orientation),
         format: Formats.TILED_JSON,
-        version: json.version,
-        properties: json.properties,
-        renderOrder: json.renderorder,
-        infinite: json.infinite
+        version: copyJsonData.version,
+        properties: copyJsonData.properties,
+        renderOrder: copyJsonData.renderorder,
+        infinite: copyJsonData.infinite
     });
 
     if (mapData.orientation === CONST.HEXAGONAL)
     {
-        mapData.hexSideLength = json.hexsidelength;
+        mapData.hexSideLength = copyJsonData.hexsidelength;
     }
 
-    mapData.layers = ParseTileLayers(json, insertNull);
-    mapData.images = ParseImageLayers(json);
+    mapData.layers = ParseTileLayers(copyJsonData, insertNull);
+    mapData.images = ParseImageLayers(copyJsonData);
 
-    var sets = ParseTilesets(json);
+    var sets = ParseTilesets(copyJsonData);
 
     mapData.tilesets = sets.tilesets;
     mapData.imageCollections = sets.imageCollections;
 
-    mapData.objects = ParseObjectLayers(json);
+    mapData.objects = ParseObjectLayers(copyJsonData);
 
     mapData.tiles = BuildTilesetIndex(mapData);
 


### PR DESCRIPTION
This PR
* Fixes a bug

A call to the ParseJSONTiled function changes the object passed as the second argument of the function, so that when this function is called again with the same object, the function returns a different result than the first call to this function.

This PR also fixes a problem described in https://github.com/photonstorm/phaser/issues/6212

before:
![image](https://user-images.githubusercontent.com/51059739/189421888-75b732a2-6ad3-41dd-9aed-527d3fc836bd.png)

after (Desired result):
![image](https://user-images.githubusercontent.com/51059739/189422022-e1bd1ead-5575-465b-9004-2542794cfb64.png)

