### PR TITLE
Rope and Video already on update list

### DIFF
--- a/src/gameobjects/rope/RopeCreator.js
+++ b/src/gameobjects/rope/RopeCreator.js
@@ -43,11 +43,6 @@ GameObjectCreator.register('rope', function (config, addToScene)
 
     BuildGameObject(this.scene, rope, config);
 
-    if (!config.add)
-    {
-        this.updateList.add(rope);
-    }
-
     return rope;
 });
 

--- a/src/gameobjects/video/VideoCreator.js
+++ b/src/gameobjects/video/VideoCreator.js
@@ -37,11 +37,6 @@ GameObjectCreator.register('video', function (config, addToScene)
 
     BuildGameObject(this.scene, video, config);
 
-    if (!config.add)
-    {
-        this.updateList.add(video);
-    }
-
     return video;
 });
 


### PR DESCRIPTION
This PR

* Fixes a bug

I think it was harmless but `make.rope()` and `make.video()` had an unnecessary branch for adding to the update list. The game objects are already added to the update list by `BuildGameObject()`.

