### PR TITLE
Tween fixes

### DIFF
--- a/src/tweens/TweenManager.js
+++ b/src/tweens/TweenManager.js
@@ -354,7 +354,7 @@ var TweenManager = new Class({
      * @method Phaser.Tweens.TweenManager#chain
      * @since 3.60.0
      *
-     * @param {Phaser.Types.Tweens.TweenBuilderConfig[]|object[]} tweens - A Tween Chain configuration object, or an array of them to create multiple chains at once.
+     * @param {Phaser.Types.Tweens.TweenChainBuilderConfig | Phaser.Types.Tweens.TweenChainBuilderConfig[]| object | object[]} tweens - A Tween Chain configuration object, or an array of them to create multiple chains at once.
      *
      * @return {(Phaser.Tweens.TweenChain|Phaser.Tweens.TweenChain[])} The Tween Chain instance, or an array of them if you passed in an array of configs.
      */

--- a/src/tweens/index.js
+++ b/src/tweens/index.js
@@ -17,8 +17,10 @@ var Tweens = {
 
     TweenManager: require('./TweenManager'),
     Tween: require('./tween/Tween'),
-    TweenData: require('./tween/TweenData')
+    TweenData: require('./tween/TweenData'),
 
+    BaseTween: require('./tween/BaseTween'),
+    TweenChain: require('./tween/TweenChain')
 };
 
 module.exports = Tweens;


### PR DESCRIPTION
* Updates the Documentation
  Phaser.Tweens.TweenManager#chain use Phaser.Types.Tweens.TweenChainBuilderConfig 
* Fixes a bug
 made BaseTween, TweenChain available in Phaser.Tweens namespace