### PR TITLE
Tween seek use less then instead of less or equal

### DIFF
--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -486,7 +486,7 @@ var Tween = new Class({
             {
                 this.update(delta);
 
-            } while (this.totalProgress <= toPosition);
+            } while (this.totalProgress < toPosition);
 
             this.isSeeking = false;
         }


### PR DESCRIPTION
* Fixes a bug
Tween seek  could do an infinite loop if the seek value was 1. 
using <  instead of <= would fix that

