### PR TITLE
Reverse order in which indexes are substracted when sorting gameobjects for inputs

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -2678,7 +2678,7 @@ var InputPlugin = new Class({
             var indexA = Math.max(list.indexOf(childA), 0);
             var indexB = Math.max(list.indexOf(childB), 0);
 
-            return indexB - indexA;
+            return indexA - indexB;
         });
     },
 

--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -632,12 +632,12 @@ var InputPlugin = new Class({
                 //  Only the top-most one counts now, so safely ignore the rest
                 if (this._temp.length)
                 {
-                    this._temp.splice(1);
+                    this._temp.splice(0, this._temp.length - 1);
                 }
 
                 if (this._tempZones.length)
                 {
-                    this._tempZones.splice(1);
+                    this._tempZones.splice(0, this._tempZones.length - 1);
                 }
             }
 
@@ -701,12 +701,12 @@ var InputPlugin = new Class({
                 //  Only the top-most one counts now, so safely ignore the rest
                 if (this._temp.length)
                 {
-                    this._temp.splice(1);
+                    this._temp.splice(0, this._temp.length - 1);
                 }
 
                 if (this._tempZones.length)
                 {
-                    this._tempZones.splice(1);
+                    this._tempZones.splice(0, this._temp.length - 1);
                 }
             }
 
@@ -1226,7 +1226,7 @@ var InputPlugin = new Class({
 
             if (this.topOnly)
             {
-                draglist.splice(1);
+                draglist.splice(0, draglist.length - 1);
             }
         }
 


### PR DESCRIPTION
This PR
* Fixes a bug

Describe the changes below:

When setting the `topOnly` property to false on the `InputPlugin`, the game objects receive the events in reverse render object (i.e bottom-most object receives before top-most).

This feels counterintuitive as they should be receiving them from top to bottom.

This PR aims to fix that by modifying the `sortGameObjects` method.