### PR TITLE
When calling the 'Phaser/Geom/Intersects#LineToLine' method without passing in the third parameter, 'out', avoid creating a new Phaser.Geom.Point, as it will be totally inaccessible.

### DIFF
--- a/src/geom/intersects/LineToLine.js
+++ b/src/geom/intersects/LineToLine.js
@@ -15,7 +15,7 @@
  *
  * @param {Phaser.Geom.Line} line1 - The first Line to check.
  * @param {Phaser.Geom.Line} line2 - The second Line to check.
- * @param {(object|Phaser.Geom.Point|Phaser.Math.Vector2)} [out] - An optional Point-like object in which to store the coordinates of intersection, if needed.
+ * @param {Phaser.Types.Math.Vector2Like} [out] - An optional point-like object in which to store the coordinates of intersection, if needed.
  *
  * @return {boolean} `true` if the two Lines intersect, and the `out` object will be populated, if given. Otherwise, `false`.
  */

--- a/src/geom/intersects/LineToLine.js
+++ b/src/geom/intersects/LineToLine.js
@@ -4,8 +4,6 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var Point = require('../point/Point');
-
 //  This is based off an explanation and expanded math presented by Paul Bourke:
 //  See http:'local.wasp.uwa.edu.au/~pbourke/geometry/lineline2d/
 
@@ -17,13 +15,12 @@ var Point = require('../point/Point');
  *
  * @param {Phaser.Geom.Line} line1 - The first Line to check.
  * @param {Phaser.Geom.Line} line2 - The second Line to check.
- * @param {Phaser.Geom.Point} [out] - A Point in which to optionally store the point of intersection.
+ * @param {(object|Phaser.Geom.Point|Phaser.Math.Vector2)} [out] - An optional Point-like object in which to store the coordinates of intersection, if needed.
  *
  * @return {boolean} `true` if the two Lines intersect, and the `out` object will be populated, if given. Otherwise, `false`.
  */
 var LineToLine = function (line1, line2, out)
 {
-    if (out === undefined) { out = new Point(); }
 
     var x1 = line1.x1;
     var y1 = line1.y1;
@@ -58,8 +55,11 @@ var LineToLine = function (line1, line2, out)
 
     if (uA >= 0 && uA <= 1 && uB >= 0 && uB <= 1)
     {
-        out.x = x1 + (uA * (x2 - x1));
-        out.y = y1 + (uA * (y2 - y1));
+        if (out)
+        {
+            out.x = x1 + (uA * (x2 - x1));
+            out.y = y1 + (uA * (y2 - y1));
+        }
 
         return true;
     }


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
Not quite a bug fix😅: just a very small performance improvement by not creating an inaccessible object.
In fact, the third parameter, 'out', must have an external reference (e.i. it must be passed in by the user), otherwise creating and populating an unreachable new Point is just a waste of memory and computing time.
