### PR TITLE
Docs: correct example code in FILE_KEY_COMPLETE

### DIFF
--- a/src/loader/events/FILE_KEY_COMPLETE_EVENT.js
+++ b/src/loader/events/FILE_KEY_COMPLETE_EVENT.js
@@ -23,7 +23,7 @@
  * Or, if you have loaded a texture `atlas` with a key of `Level1`:
  *
  * ```javascript
- * this.load.on('filecomplete-atlas-Level1', function (key, type, data) {
+ * this.load.on('filecomplete-atlasjson-Level1', function (key, type, data) {
  *     // Your handler code
  * });
  * ```


### PR DESCRIPTION
This PR

* Updates the Documentation

AtlasJSONFile type is `atlasjson`