### PR TITLE
Fixed getPostPipeline

### DIFF
--- a/src/gameobjects/components/Pipeline.js
+++ b/src/gameobjects/components/Pipeline.js
@@ -292,7 +292,7 @@ var Pipeline = {
         {
             var instance = pipelines[i];
 
-            if ((typeof pipeline === 'string' && instance.name === pipeline) || instance instanceof pipeline)
+            if (typeof pipeline === 'string' ? (instance.name === pipeline) : (instance instanceof pipeline))
             {
                 results.push(instance);
             }


### PR DESCRIPTION
If pass parameter as **string** (pipeline name) to `getPostPipeline`, then get error:

```
Uncaught TypeError: Right-hand side of 'instanceof' is not an object
```

This happens when there is pipeline with name different from the one are looking for.
I changed the condition to solve this problem.

