### PR TITLE
fix advancedWordWrap concatenate when wrapping

### DIFF
--- a/src/gameobjects/text/Text.js
+++ b/src/gameobjects/text/Text.js
@@ -465,7 +465,7 @@ var Text = new Class({
                         .replace(/[ \n]*$/gi, '');
 
                     // Prepend remainder to next line
-                    lines[i + 1] = remainder + ' ' + (lines[i + 1] || '');
+                    lines.splice(i + 1, 0, remainder);
                     linesCount = lines.length;
 
                     break; // Processing on this line


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
advancedWordWrap function merges current and next lines when wrapping words
Issue link: https://github.com/photonstorm/phaser/issues/6187

