### PR TITLE
Update spine build config to match newer spine runtimes.

### DIFF
--- a/plugins/spine/tsconfig.both.json
+++ b/plugins/spine/tsconfig.both.json
@@ -7,18 +7,18 @@
         "preserveConstEnums": true,
         "outFile": "src/runtimes/spine-both.js",
         "sourceMap": true,
-        "declaration": true
+        "declaration": true,
+        "target": "es6"
     },
     "include": [
-        "spine-runtimes/spine-ts/core/src/**/*",
-        "spine-runtimes/spine-ts/canvas/src/**/*",
-        "spine-runtimes/spine-ts/webgl/src/**/*"
+        "spine-runtimes/spine-ts/spine-core/src/**/*",
+        "spine-runtimes/spine-ts/spine-canvas/src/**/*",
+        "spine-runtimes/spine-ts/spine-webgl/src/**/*"
     ],
     "exclude": [
-        "spine-runtimes/spine-ts/build",
-        "spine-runtimes/spine-ts/player",
-        "spine-runtimes/spine-ts/threejs",
-        "spine-runtimes/spine-ts/webgl/src/Input.ts",
-        "spine-runtimes/spine-ts/webgl/src/LoadingScreen.ts"
+        "spine-runtimes/spine-ts/spine-player",
+        "spine-runtimes/spine-ts/spine-threejs",
+        "spine-runtimes/spine-ts/spine-webgl/src/Input.ts",
+        "spine-runtimes/spine-ts/spine-webgl/src/LoadingScreen.ts"
     ]
 }

--- a/plugins/spine/tsconfig.canvas.json
+++ b/plugins/spine/tsconfig.canvas.json
@@ -7,17 +7,16 @@
 		"preserveConstEnums": true,
 		"outFile": "src/runtimes/spine-canvas.js",
 		"sourceMap": true,
-		"declaration": true
+		"declaration": true,
+        "target": "es6"
 	},
 	"include": [
-		"spine-runtimes/spine-ts/core/src/**/*",
-		"spine-runtimes/spine-ts/canvas/src/**/*"
+		"spine-runtimes/spine-ts/spine-core/src/**/*",
+		"spine-runtimes/spine-ts/spine-canvas/src/**/*"
 	],
 	"exclude": [
-		"spine-runtimes/spine-ts/webgl",
-		"spine-runtimes/spine-ts/widget",
-		"spine-runtimes/spine-ts/threejs",
-		"spine-runtimes/spine-ts/build",
-        "spine-runtimes/spine-ts/player"
+		"spine-runtimes/spine-ts/spine-webgl",
+		"spine-runtimes/spine-ts/spine-threejs",
+        "spine-runtimes/spine-ts/spine-player"
 	]
 }

--- a/plugins/spine/tsconfig.webgl.json
+++ b/plugins/spine/tsconfig.webgl.json
@@ -7,18 +7,17 @@
 		"preserveConstEnums": true,
 		"outFile": "src/runtimes/spine-webgl.js",
 		"sourceMap": true,
-		"declaration": true
+		"declaration": true,
+        "target": "es6"
 	},
 	"include": [
-		"spine-runtimes/spine-ts/core/src/**/*",
-		"spine-runtimes/spine-ts/webgl/src/**/*"
+		"spine-runtimes/spine-ts/spine-core/src/**/*",
+		"spine-runtimes/spine-ts/spine-webgl/src/**/*"
 	],
 	"exclude": [
-		"spine-runtimes/spine-ts/canvas",
-		"spine-runtimes/spine-ts/widget",
-		"spine-runtimes/spine-ts/threejs",
-		"spine-runtimes/spine-ts/build",
-        "spine-runtimes/spine-ts/webgl/src/Input.ts",
-        "spine-runtimes/spine-ts/webgl/src/LoadingScreen.ts"
+		"spine-runtimes/spine-ts/spine-canvas",
+		"spine-runtimes/spine-ts/spine-threejs",
+        "spine-runtimes/spine-ts/spine-webgl/src/Input.ts",
+        "spine-runtimes/spine-ts/spine-webgl/src/LoadingScreen.ts"
 	]
 }


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The spine plugin build configs have been updated to match the source code of newer versions of the spine runtime. This will no longer work for spine-runtime 3.8, but I guess that should not be a problem? I think the build readme also is slightly outdated, but I am not sure.