### PR TITLE
 fixed Phaser.Actions.Spread step value so the last element is equal max

### DIFF
--- a/src/actions/Spread.js
+++ b/src/actions/Spread.js
@@ -32,8 +32,22 @@
 var Spread = function (items, property, min, max, inc)
 {
     if (inc === undefined) { inc = false; }
+    if (items.length === 0) { return items; }
+    if (items.length === 1) // if only one item put it at the center
+    {
+        if (inc)
+        {
+            items[0][property] += (max + min) / 2;
+        }
+        else
+        {
+            items[0][property] = (max + min) / 2;
+        }
 
-    var step = Math.abs(max - min) / items.length;
+        return items;
+    }
+
+    var step = Math.abs(max - min) / (items.length - 1);
     var i;
 
     if (inc)


### PR DESCRIPTION
This PR:
 * Fixes a bug
 
Describe the changes below:

Spread would have step value as if items had 1 more element. 
Meaning the last element would not be equal to max.

Her is an example showing bug and how the new code fixes it:
```javascript
var NewSpread = function (items, property, min, max, inc)
{
    if (inc === undefined) { inc = false; }
    if (items.length === 0) { return items; }
    if (items.length === 1) // if only one item put it at the center
    {
        if (inc)
        {
            items[0][property] += (max + min) / 2;
        }
        else
        {
            items[0][property] = (max + min) / 2;
        }

        return items;
    }

    var step = Math.abs(max - min) / (items.length - 1);
    var i;

    if (inc)
    {
        for (i = 0; i < items.length; i++)
        {
            items[i][property] += i * step + min;
        }
    }
    else
    {
        for (i = 0; i < items.length; i++)
        {
            items[i][property] = i * step + min;
        }
    }

    return items;
};

class Example extends Phaser.Scene
{
    constructor ()
    {
        super();
    }

    preload ()
    {
        this.load.spritesheet('diamonds', 'assets/sprites/diamonds32x24x5.png', { frameWidth: 32, frameHeight: 24 });
    }

    create ()
    {
        const group1 = this.add.group({ key: 'diamonds', frame: 3, frameQuantity: 4, setXY: { x: 32, y: 32, stepX: 14 }});

        Phaser.Actions.Spread(group1.getChildren(), 'alpha', 0, 1);

        const children1 = group1.getChildren()

        console.log(children1[children1.length-1].alpha)

        const group2 = this.add.group({ key: 'diamonds', frame: 3, frameQuantity: 4, setXY: { x: 32, y: 64, stepX: 14 }});

        NewSpread(group2.getChildren(), 'alpha', 0, 1);

        const children2 = group2.getChildren()

        console.log(children2[children2.length-1].alpha)
    }
}

const config = {
    type: Phaser.AUTO,
    width: 800,
    height: 600,
    parent: 'phaser-example',
    scene: [ Example ]
};

const game = new Phaser.Game(config);

```