### PR TITLE
Fix Issue #6301 causing tilemap collisions to fail.

### DIFF
--- a/src/tilemaps/components/WorldToTileXY.js
+++ b/src/tilemaps/components/WorldToTileXY.js
@@ -25,7 +25,7 @@ var Vector2 = require('../../math/Vector2');
  */
 var WorldToTileXY = function (worldX, worldY, snapToFloor, point, camera, layer)
 {
-    if (!snapToFloor) { snapToFloor = true; }
+    if (snapToFloor === undefined) { snapToFloor = true; }
     if (!point) { point = new Vector2(); }
 
     var tileWidth = layer.baseTileWidth;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Check specifically if `snapToFloor` is undefined, vs. false. Reverting a change made earlier, in order to fix a bug with tile map collisions.

This is related to issue #6301 