### PR TITLE
Add `lineSpacing` property and `setLineSpacing` method to BitmapText

### DIFF
--- a/src/gameobjects/bitmaptext/GetBitmapTextSize.js
+++ b/src/gameobjects/bitmaptext/GetBitmapTextSize.js
@@ -73,6 +73,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
     var chars = src.fontData.chars;
     var lineHeight = src.fontData.lineHeight;
     var letterSpacing = src.letterSpacing;
+    var lineSpacing = src.lineSpacing;
 
     var xAdvance = 0;
     var yAdvance = 0;
@@ -128,7 +129,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
                 }
 
                 xAdvance = 0;
-                yAdvance += lineHeight;
+                yAdvance += lineHeight + lineSpacing;
                 lastGlyph = null;
 
                 continue;
@@ -291,7 +292,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
             }
 
             xAdvance = 0;
-            yAdvance += lineHeight;
+            yAdvance += lineHeight + lineSpacing;
             lastGlyph = null;
 
             lineWidths[currentLine] = currentLineWidth;

--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -154,6 +154,18 @@ var BitmapText = new Class({
         this._letterSpacing = 0;
 
         /**
+         * Adds / Removes spacing lines in a multiline BitmapText object.
+         *
+         * Can be a negative or positive number.
+         *
+         * @name Phaser.GameObjects.BitmapText#_lineSpacing
+         * @type {number}
+         * @private
+         * @since 3.60.0
+         */
+        this._lineSpacing = 0;
+
+        /**
          * Controls the alignment of each line of text in this BitmapText object.
          * Only has any effect when this BitmapText contains multiple lines of text, split with carriage-returns.
          * Has no effect with single-lines of text.
@@ -375,6 +387,28 @@ var BitmapText = new Class({
         if (spacing === undefined) { spacing = 0; }
 
         this._letterSpacing = spacing;
+
+        this._dirty = true;
+
+        return this;
+    },
+
+
+    /**
+     * The line spacing value.
+     * This value is added to the font height to calculate the overall line height.
+     * Only has an effect if this Text object contains multiple lines of text.
+     *
+     *
+     * @name Phaser.GameObjects.Text#lineSpacing
+     * @type {number}
+     * @since 3.60.0
+     */
+    setLineSpacing: function (spacing)
+    {
+        if (spacing === undefined) { spacing = 0; }
+
+        this._lineSpacing = spacing;
 
         this._dirty = true;
 
@@ -918,6 +952,32 @@ var BitmapText = new Class({
         get: function ()
         {
             return this._letterSpacing;
+        }
+
+    },
+
+    /**
+     * Adds / Removes spacing between lines.
+     *
+     * Can be a negative or positive number.
+     *
+     * You can also use the method `setLineSpacing` if you want a chainable way to change the line spacing.
+     *
+     * @name Phaser.GameObjects.BitmapText#lineSpacing
+     * @type {number}
+     * @since 3.60.0
+     */
+    lineSpacing: {
+
+        set: function (value)
+        {
+            this._lineSpacing = value;
+            this._dirty = true;
+        },
+
+        get: function ()
+        {
+            return this._lineSpacing;
         }
 
     },

--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -400,7 +400,7 @@ var BitmapText = new Class({
      * Only has an effect if this Text object contains multiple lines of text.
      *
      *
-     * @name Phaser.GameObjects.BitmapText#lineSpacing
+     * @name Phaser.GameObjects.BitmapText#setLineSpacing
      * @type {number}
      * @since 3.60.0
      */

--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -154,7 +154,7 @@ var BitmapText = new Class({
         this._letterSpacing = 0;
 
         /**
-         * Adds / Removes spacing lines in a multiline BitmapText object.
+         * Adds / Removes line spacing in a multiline BitmapText object.
          *
          * Can be a negative or positive number.
          *
@@ -1114,6 +1114,7 @@ var BitmapText = new Class({
             text: this.text,
             fontSize: this.fontSize,
             letterSpacing: this.letterSpacing,
+            lineSpacing: this.lineSpacing,
             align: this.align
         };
 

--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -400,7 +400,7 @@ var BitmapText = new Class({
      * Only has an effect if this Text object contains multiple lines of text.
      *
      *
-     * @name Phaser.GameObjects.Text#lineSpacing
+     * @name Phaser.GameObjects.BitmapText#lineSpacing
      * @type {number}
      * @since 3.60.0
      */

--- a/src/gameobjects/bitmaptext/static/BitmapTextCanvasRenderer.js
+++ b/src/gameobjects/bitmaptext/static/BitmapTextCanvasRenderer.js
@@ -41,6 +41,7 @@ var BitmapTextCanvasRenderer = function (renderer, src, camera, parentMatrix)
     var chars = src.fontData.chars;
     var lineHeight = src.fontData.lineHeight;
     var letterSpacing = src._letterSpacing;
+    var lineSpacing = src._lineSpacing;
 
     var xAdvance = 0;
     var yAdvance = 0;
@@ -113,7 +114,8 @@ var BitmapTextCanvasRenderer = function (renderer, src, camera, parentMatrix)
             }
 
             xAdvance = 0;
-            yAdvance += lineHeight;
+            yAdvance += lineHeight + lineSpacing;
+
             lastGlyph = null;
 
             continue;


### PR DESCRIPTION
A similar feature to the `Text`'s `lineSpacing`

Should work in both Canvas and WebGL modes
For a text displaying a single line `lineSpacing` has no influence on height nor its bounds