### PR TITLE
Add additional type to orientation property

### DIFF
--- a/src/tilemaps/typedefs/MapDataConfig.js
+++ b/src/tilemaps/typedefs/MapDataConfig.js
@@ -10,7 +10,7 @@
  * @property {number} [widthInPixels] - The width in pixels of the entire tilemap.
  * @property {number} [heightInPixels] - The height in pixels of the entire tilemap.
  * @property {number} [format] - The format of the Tilemap, as defined in Tiled.
- * @property {string} [orientation] - The orientation of the map data (i.e. orthogonal, isometric, hexagonal), default 'orthogonal'.
+ * @property {(string|Phaser.Tilemaps.Orientation)} [orientation] - The orientation of the map data (i.e. orthogonal, isometric, hexagonal), default 'orthogonal'.
  * @property {string} [renderOrder] - Determines the draw order of tilemap. Default is right-down.
  * @property {number} [version] - The version of Tiled the map uses.
  * @property {number} [properties] - Map specific properties (can be specified in Tiled).


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:
Adds an additional type (`Phaser.Tilemaps.Orientation`) to the orientation property of the MapDataConfig type definition.
