### PR TITLE
Docs: change "Constructor" types to `function`

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -126,9 +126,10 @@ var Group = new Class({
          * The class to create new group members from.
          *
          * @name Phaser.GameObjects.Group#classType
-         * @type {Phaser.Types.GameObjects.Group.GroupClassTypeConstructor}
+         * @type {function}
          * @since 3.0.0
          * @default Phaser.GameObjects.Sprite
+         * @see Phaser.Types.GameObjects.Group.GroupClassTypeConstructor
          */
         this.classType = GetFastValue(config, 'classType', Sprite);
 

--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -310,9 +310,10 @@ var ParticleEmitter = new Class({
          * The Particle Class which will be emitted by this Emitter.
          *
          * @name Phaser.GameObjects.Particles.ParticleEmitter#particleClass
-         * @type {Phaser.Types.GameObjects.Particles.ParticleClassConstructor}
+         * @type {function}
          * @default Phaser.GameObjects.Particles.Particle
          * @since 3.0.0
+         * @see Phaser.Types.GameObjects.Particles.ParticleClassConstructor
          */
         this.particleClass = Particle;
 

--- a/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
+++ b/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
@@ -22,7 +22,7 @@
  * @property {string} [name] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#name}.
  * @property {boolean} [on] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#on}.
  * @property {boolean} [particleBringToTop] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#particleBringToTop}.
- * @property {Phaser.Types.GameObjects.Particles.ParticleClassConstructor} [particleClass] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#particleClass}.
+ * @property {function} [particleClass] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#particleClass}.
  * @property {boolean} [radial] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#radial}.
  * @property {number} [timeScale] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#timeScale}.
  * @property {boolean} [trackVisible] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#trackVisible}.

--- a/src/physics/arcade/PhysicsGroup.js
+++ b/src/physics/arcade/PhysicsGroup.js
@@ -103,9 +103,10 @@ var PhysicsGroup = new Class({
          * This should be either `Phaser.Physics.Arcade.Image`, `Phaser.Physics.Arcade.Sprite`, or a class extending one of those.
          *
          * @name Phaser.Physics.Arcade.Group#classType
-         * @type {Phaser.Types.GameObjects.Group.GroupClassTypeConstructor}
+         * @type {function}
          * @default ArcadeSprite
          * @since 3.0.0
+         * @see Phaser.Types.GameObjects.Group.GroupClassTypeConstructor
          */
         config.classType = GetFastValue(config, 'classType', ArcadeSprite);
 

--- a/src/tilemaps/typedefs/CreateFromObjectLayerConfig.js
+++ b/src/tilemaps/typedefs/CreateFromObjectLayerConfig.js
@@ -6,7 +6,7 @@
  * @property {number} [gid] - An Object GID to convert.
  * @property {string} [name] - An Object Name to convert.
  * @property {string} [type] - An Object Type to convert.
- * @property {Phaser.Types.Tilemaps.CreateFromObjectsClassTypeConstructor} [classType] - A custom class type to convert the objects in to. The default is {@link Phaser.GameObjects.Sprite}. A custom class should resemble Sprite or Image.
+ * @property {function} [classType] - A custom class type to convert the objects in to. The default is {@link Phaser.GameObjects.Sprite}. A custom class should resemble Sprite or Image; see {@link Phaser.Types.Tilemaps.CreateFromObjectsClassTypeConstructor}.
  * @property {boolean} [ignoreTileset] - By default, gid-based objects copy properties and respect the type of the tile at that gid and treat the object as an override. If this is true, they don't, and use only the fields set on the object itself.
  * @property {Phaser.Scene} [scene] - A Scene reference, passed to the Game Objects constructors.
  * @property {Phaser.GameObjects.Container} [container] - Optional Container to which the Game Objects are added.


### PR DESCRIPTION
This PR

* Updates the Documentation

I removed these as types but kept them as JSDoc links.

- Phaser.Types.GameObjects.Group.GroupClassTypeConstructor
- Phaser.Types.GameObjects.Particles.ParticleClassConstructor
- Phaser.Types.Tilemaps.CreateFromObjectsClassTypeConstructor

Fixes #6318
