### PR TITLE
fix the bug when Edge and Opera browsers are not defined

### DIFF
--- a/src/device/Browser.js
+++ b/src/device/Browser.js
@@ -54,9 +54,13 @@ function init ()
 {
     var ua = navigator.userAgent;
 
-    if ((/Edge\/\d+/).test(ua))
+    if ((/Edg\/\d+/).test(ua))
     {
         Browser.edge = true;
+        Browser.es2019 = true;
+    }
+    else if ((/OPR/).test(ua)) {
+        Browser.opera = true;
         Browser.es2019 = true;
     }
     else if ((/Chrome\/(\d+)/).test(ua) && !OS.windowsPhone)
@@ -79,11 +83,6 @@ function init ()
     {
         Browser.ie = true;
         Browser.ieVersion = parseInt(RegExp.$1, 10);
-    }
-    else if ((/Opera/).test(ua))
-    {
-        Browser.opera = true;
-        Browser.es2019 = true;
     }
     else if ((/Version\/(\d+\.\d+) Safari/).test(ua) && !OS.windowsPhone)
     {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation
* Adds a new feature
* Fixes a bug

Describe the changes below:
The problem is that two browsers are incorrectly defined: Edge and Opera. The reason was found - the value of the string "navigator.userAgent" has changed.
Browsers where the error was detected:
Edge 108.0.1462.54
Opera 94.0.4606.38

I found the problem using the latest version of Phaser in my project, you can also see it here: https://jsfiddle.net/artem_syzonenko/4ng20okq/

![edge_v_108 0 1462 54](https://user-images.githubusercontent.com/23199424/209672695-f5ffeac5-8652-412f-9a3a-e9e963e95431.png)

![opera_1_94 0 4606 38](https://user-images.githubusercontent.com/23199424/209672718-4d7c49f4-a546-4d4d-b110-7c6c62d6a1ca.png)
![opera_2_94 0 4606 38](https://user-images.githubusercontent.com/23199424/209672721-dc897270-84c3-49d2-8b8c-9e3c2fb690cb.png)
