### PR TITLE
Fix: Tween UpdateTo throws error

### DIFF
--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -289,13 +289,13 @@ var Tween = new Class({
     {
         if (startToCurrent === undefined) { startToCurrent = false; }
 
-        if (key !== 'texture' && (this.isPlayingForward() || this.isPlayingBackward()))
+        if (key !== 'texture')
         {
             for (var i = 0; i < this.totalData; i++)
             {
                 var tweenData = this.data[i];
 
-                if (tweenData.key === key)
+                if (tweenData.key === key && (tweenData.isPlayingForward() || tweenData.isPlayingBackward()))
                 {
                     tweenData.end = value;
 


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

Fixes `TypeError: this.isPlayingForward is not a function at Tween.updateTo` error when calling Tween updateTo.
Resolves #6313 