### PR TITLE
plugins/spine4.1/copy-to-examples.js path fixed

### DIFF
--- a/plugins/spine4.1/copy-to-examples.js
+++ b/plugins/spine4.1/copy-to-examples.js
@@ -1,7 +1,7 @@
 var fs = require('fs-extra');
 
 var source = './plugins/spine4.1/dist/';
-var dest = '../phaser3-examples/public/plugins/3.8.95/';
+var dest = '../phaser3-examples/public/plugins/spine4.1/';
 
 if (fs.existsSync(dest))
 {


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

I added spine4.1 in phaser3-examples:

https://github.com/photonstorm/phaser3-examples/pull/386

So fixed plugins/spine4.1/copy-to-examples.js path