### PR TITLE
Improve the missing frame/texture handling when creating animations

### DIFF
--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -399,6 +399,13 @@ var Animation = new Class({
         {
             textureKey = frames;
 
+            if (!textureManager.exists(textureKey))
+            {
+                console.warn('Texture "%s" not found', textureKey);
+
+                return out;
+            }
+
             var texture = textureManager.get(textureKey);
             var frameKeys = texture.getFrameNames();
 
@@ -436,6 +443,13 @@ var Animation = new Class({
 
             //  The actual texture frame
             var textureFrame = textureManager.getFrame(key, frame);
+
+            if (!textureFrame)
+            {
+                console.warn('Texture "%s" not found', key);
+
+                continue;
+            }
 
             animationFrame = new Frame(key, frame, index, textureFrame);
 

--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -763,13 +763,15 @@ var AnimationManager = new Class({
 
         for (var i = 0; i < frames.length; i++)
         {
-            if (texture.has(frames[i]))
+            var frameName = frames[i];
+
+            if (texture.has(frameName))
             {
-                out.push({ key: key, frame: frames[i] });
+                out.push({ key: key, frame: frameName });
             }
             else
             {
-                console.warn('generateFrameNumbers: Frame ' + i + ' missing from texture: ' + key);
+                console.warn('Frame "%s" not found in texture "%s"', frameName, key);
             }
         }
 

--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -637,6 +637,13 @@ var AnimationManager = new Class({
         var out = GetValue(config, 'outputArray', []);
         var frames = GetValue(config, 'frames', false);
 
+        if (!this.textureManager.exists(key))
+        {
+            console.warn('Texture "%s" not found', key);
+
+            return out;
+        }
+
         var texture = this.textureManager.get(key);
 
         if (!texture)
@@ -673,7 +680,7 @@ var AnimationManager = new Class({
                 }
                 else
                 {
-                    console.warn('generateFrameNames: Frame missing: ' + frame + ' from texture: ' + key);
+                    console.warn('Frame "%s" not found in texture "%s"', frame, key);
                 }
             }
         }
@@ -735,6 +742,13 @@ var AnimationManager = new Class({
         var first = GetValue(config, 'first', false);
         var out = GetValue(config, 'outputArray', []);
         var frames = GetValue(config, 'frames', false);
+
+        if (!this.textureManager.exists(key))
+        {
+            console.warn('Texture "%s" not found', key);
+
+            return out;
+        }
 
         var texture = this.textureManager.get(key);
 


### PR DESCRIPTION
This PR

* Adds a new feature
* Fixes a bug

Fixed
-----

The "missing frame" console warning in `generateFrameNumbers()` was printing the loop index instead of the frame name.

Changed
-------

Before if you gave a bad texture `key` in an animation frame config, there was no console message and an invalid animation frame was created (undefined `frame`). Now a console warning is printed and no animation frame is created.

Before if you gave a bad texture key as `frames` in an animation config, there was no console message. Now a console warning is printed.

Before if you gave a bad texture key to `generateFrameNames()` or `generateFrameNumbers()` they would print a "missing frame" warning for each animation frame config. Now they print one "texture not found" warning and abort without trying to select frames.
 




