### PR TITLE
Warn if no audio URLs are matched

### DIFF
--- a/src/loader/filetypes/AudioFile.js
+++ b/src/loader/filetypes/AudioFile.js
@@ -116,6 +116,8 @@ AudioFile.create = function (loader, key, urls, config, xhrSettings)
 
     if (!urlConfig)
     {
+        console.warn('No audio URLs for "%s" matched this device', key);
+
         return null;
     }
 


### PR DESCRIPTION
This PR

* Adds a new feature

I think authors need help identifying this problem. So here is a new console warning:

> No audio URLs for [key] matched this device



