### PR TITLE
Few type fixes

### DIFF
--- a/src/gameobjects/graphics/GraphicsCreator.js
+++ b/src/gameobjects/graphics/GraphicsCreator.js
@@ -15,7 +15,7 @@ var Graphics = require('./Graphics');
  * @method Phaser.GameObjects.GameObjectCreator#graphics
  * @since 3.0.0
  *
- * @param {Phaser.Types.GameObjects.Graphics.Options} config - The configuration object this Game Object will use to create itself.
+ * @param {Phaser.Types.GameObjects.Graphics.Options} [config] - The configuration object this Game Object will use to create itself.
  * @param {boolean} [addToScene] - Add this Game Object to the Scene after creating it? If set this argument overrides the `add` property in the config object.
  *
  * @return {Phaser.GameObjects.Graphics} The Game Object that was created.

--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -728,7 +728,7 @@ var ParticleEmitter = new Class({
          * @type {boolean}
          * @default true
          * @since 3.0.0
-         * @see Phaser.GameObjects.Particles.ParticleEmitter#setFrame
+         * @see Phaser.GameObjects.Particles.ParticleEmitter#setEmitterFrame
          */
         this.randomFrame = true;
 
@@ -739,7 +739,7 @@ var ParticleEmitter = new Class({
          * @type {number}
          * @default 1
          * @since 3.0.0
-         * @see Phaser.GameObjects.Particles.ParticleEmitter#setFrame
+         * @see Phaser.GameObjects.Particles.ParticleEmitter#setEmitterFrame
          */
         this.frameQuantity = 1;
 

--- a/src/gameobjects/text/typedefs/TextStyle.js
+++ b/src/gameobjects/text/typedefs/TextStyle.js
@@ -5,7 +5,7 @@
  * @since 3.0.0
  *
  * @property {string} [fontFamily='Courier'] - The font the Text object will render with. This is a Canvas style font string.
- * @property {string} [fontSize='16px'] - The font size, as a CSS size string.
+ * @property {(number|string)} [fontSize='16px'] - The font size, as a CSS size string.
  * @property {string} [fontStyle] - Any addition font styles, such as 'strong'.
  * @property {string} [font] - The font family or font settings to set. Overrides the other font settings.
  * @property {string} [backgroundColor] - A solid fill color that is rendered behind the Text object. Given as a CSS string color such as `#ff0`.

--- a/src/gameobjects/text/typedefs/TextStyle.js
+++ b/src/gameobjects/text/typedefs/TextStyle.js
@@ -25,4 +25,5 @@
  * @property {number} [baselineY=1.4] - The amount of vertical padding added to the height of the text when calculating the font metrics.
  * @property {Phaser.Types.GameObjects.Text.TextWordWrap} [wordWrap] - The Text Word wrap configuration object.
  * @property {Phaser.Types.GameObjects.Text.TextMetrics} [metrics] - A Text Metrics object. Use this to avoid expensive font size calculations in text heavy games.
+ * @property {number} [lineSpacing] - The amount to add to the font height to achieve the overall line height.
  */


### PR DESCRIPTION
This PR 

* Updates the Documentation

Updates `fontSize` type to avoid errors when passing a number value withing `TextStyle` config when passed to `this.add.text` call, and adds missing `lineSpacing` property.

Optional `config` param for `Phaser.GameObjects.GameObjectCreator#graphics` method.

`ParticleEmitter` docs reference updated method name `setEmitterFrame`.

