### PR TITLE
Fixed addSpriteSheetFromAtlas exception

### DIFF
--- a/src/textures/parsers/SpriteSheetFromAtlas.js
+++ b/src/textures/parsers/SpriteSheetFromAtlas.js
@@ -93,7 +93,7 @@ var SpriteSheetFromAtlas = function (texture, frame, config)
     var frameX = margin;
     var frameY = margin;
     var frameIndex = 0;
-    var sourceIndex = frame.sourceIndex;
+    var sourceIndex = 0;
 
     for (var sheetY = 0; sheetY < column; sheetY++)
     {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
Resolves #6363.
The parser `SpriteSheetFromAtlas` was using the incorrect sourceIndex to grab frames from a given texture. 
This caused a crash whenever a trimmed spritesheet was added from any multiatlas image other than the first.
[More detail about this on the Discord.](https://discord.com/channels/244245946873937922/416623653741133837/1068029678801137764)

