### PR TITLE
Improve particles types

### DIFF
--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -1958,9 +1958,10 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#addParticleProcessor
      * @since 3.60.0
      *
-     * @param {Phaser.GameObjects.Particles.ParticleProcessor} processor - The Particle Processor to add to this Emitter Manager.
+     * @generic {Phaser.GameObjects.Particles.ParticleProcessor} T
+     * @param {T} processor - The Particle Processor to add to this Emitter Manager.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleProcessor} The Particle Processor that was added to this Emitter Manager.
+     * @return {T} The Particle Processor that was added to this Emitter Manager.
      */
     addParticleProcessor: function (processor)
     {
@@ -1990,9 +1991,10 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#removeParticleProcessor
      * @since 3.60.0
      *
-     * @param {Phaser.GameObjects.Particles.ParticleProcessor} processor - The Particle Processor to remove from this Emitter Manager.
+     * @generic {Phaser.GameObjects.Particles.ParticleProcessor} T
+     * @param {T} processor - The Particle Processor to remove from this Emitter Manager.
      *
-     * @return {?Phaser.GameObjects.Particles.ParticleProcessor} The Particle Processor that was removed, or null if it could not be found.
+     * @return {?T} The Particle Processor that was removed, or null if it could not be found.
      */
     removeParticleProcessor: function (processor)
     {

--- a/src/gameobjects/particles/typedefs/ParticleEmitterOps.js
+++ b/src/gameobjects/particles/typedefs/ParticleEmitterOps.js
@@ -1,27 +1,27 @@
 /**
- * @callback Phaser.Types.GameObjects.Particles.ParticleEmitterOps
+ * @typedef {object} Phaser.Types.GameObjects.Particles.ParticleEmitterOps
  * @since 3.60.0
  *
- * @param {Phaser.GameObjects.Particles.EmitterOp} accelerationX - The accelerationX EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} accelerationY - The accelerationY EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} alpha - The alpha EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} angle - The angle EmitterOp instance. This is an onEmit operator only.
- * @param {Phaser.GameObjects.Particles.EmitterOp} bounce - The bounce EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterColorOp} color - The color EmitterColorOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} delay - The delay EmitterOp instance. This is an onEmit operator only.
- * @param {Phaser.GameObjects.Particles.EmitterOp} hold - The hold EmitterOp instance. This is an onEmit operator only.
- * @param {Phaser.GameObjects.Particles.EmitterOp} lifespan - The lifespan EmitterOp instance. This is an onEmit operator only.
- * @param {Phaser.GameObjects.Particles.EmitterOp} maxVelocityX - The maxVelocityX EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} maxVelocityY - The maxVelocityY EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} moveToX - The moveToX EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} moveToY - The moveToY EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} quantity - The quantity EmitterOp instance. This is an onEmit operator only.
- * @param {Phaser.GameObjects.Particles.EmitterOp} rotate - The rotate EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} scaleX - The scaleX EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} scaleY - The scaleY EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} speedX - The speedX EmitterOp instance. This is an onEmit operator only.
- * @param {Phaser.GameObjects.Particles.EmitterOp} speedY - The speedY EmitterOp instance. This is an onEmit operator only.
- * @param {Phaser.GameObjects.Particles.EmitterOp} tint - The tint EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} x - The x EmitterOp instance. This is an onEmit and onUpdate operator.
- * @param {Phaser.GameObjects.Particles.EmitterOp} y - The y EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} accelerationX - The accelerationX EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} accelerationY - The accelerationY EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} alpha - The alpha EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} angle - The angle EmitterOp instance. This is an onEmit operator only.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} bounce - The bounce EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterColorOp} color - The color EmitterColorOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} delay - The delay EmitterOp instance. This is an onEmit operator only.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} hold - The hold EmitterOp instance. This is an onEmit operator only.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} lifespan - The lifespan EmitterOp instance. This is an onEmit operator only.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} maxVelocityX - The maxVelocityX EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} maxVelocityY - The maxVelocityY EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} moveToX - The moveToX EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} moveToY - The moveToY EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} quantity - The quantity EmitterOp instance. This is an onEmit operator only.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} rotate - The rotate EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} scaleX - The scaleX EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} scaleY - The scaleY EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} speedX - The speedX EmitterOp instance. This is an onEmit operator only.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} speedY - The speedY EmitterOp instance. This is an onEmit operator only.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} tint - The tint EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} x - The x EmitterOp instance. This is an onEmit and onUpdate operator.
+ * @property {Phaser.GameObjects.Particles.EmitterOp} y - The y EmitterOp instance. This is an onEmit and onUpdate operator.
  */


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the typescript defs

Describe the changes below:
- make addParticleProcessor & removeParticleProcessor methods generic
- ParticleEmitterOps is an object not a callback
