### PR TITLE
Add exclusive camera feature

### DIFF
--- a/src/cameras/2d/BaseCamera.js
+++ b/src/cameras/2d/BaseCamera.js
@@ -517,6 +517,18 @@ var BaseCamera = new Class({
          * @since 3.60.0
          */
         this.isSceneCamera = true;
+        
+        /**
+         * Exclusive camera will ignore all game objects, 
+         * only accepted game objects will be rendered.
+         *
+         * @name Phaser.Cameras.Scene2D.BaseCamera#exclusive
+         * @type {boolean}
+         * @default false
+         * @since 3.60.0
+         */
+        this.exclusive = false;
+
     },
 
     /**
@@ -908,6 +920,65 @@ var BaseCamera = new Class({
                 entry.cameraFilter |= id;
             }
         }
+
+        return this;
+    },
+
+    /**
+     * Enable exclusive camera, only accepted game objects will be rendered.
+     *
+     * @method Phaser.Cameras.Scene2D.BaseCamera#setExclusiveEnable
+     * @since 3.60.0
+     *
+     * @return {this} This Camera instance.
+     */
+    setExclusive: function()
+    {
+        this.exclusive = true;
+
+        return this;
+    },
+
+    /**
+     * For exclusive camera, given a Game Object, or an array of Game Objects, it will update all of their camera filter2 settings
+     * so that they are accepted by this Camera. This means they will be rendered by this Camera.
+     *
+     * @method Phaser.Cameras.Scene2D.BaseCamera#accept
+     * @since 3.60.0
+     *
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[]|Phaser.GameObjects.Group)} entries - The Game Object, or array of Game Objects, to be ignored by this Camera.
+     *
+     * @return {this} This Camera instance.
+     */
+    accept: function (entries)
+    {
+        var id = this.id;
+
+        if (!Array.isArray(entries))
+        {
+            entries = [ entries ];
+        }
+
+        for (var i = 0; i < entries.length; i++)
+        {
+            var entry = entries[i];
+
+            if (Array.isArray(entry))
+            {
+                this.ignore(entry);
+            }
+            else if (entry.isParent)
+            {
+                this.ignore(entry.getChildren());
+            }
+            else
+            {
+                entry.cameraFilter2 |= id;
+
+                // Don't render by all other cameras
+                entry.cameraFilter = 0xffffffff;
+            }
+        }        
 
         return this;
     },

--- a/src/cameras/2d/CameraManager.js
+++ b/src/cameras/2d/CameraManager.js
@@ -426,6 +426,7 @@ var CameraManager = new Class({
             camera.scrollY = GetFastValue(cameraConfig, 'scrollY', 0);
             camera.roundPixels = GetFastValue(cameraConfig, 'roundPixels', false);
             camera.visible = GetFastValue(cameraConfig, 'visible', true);
+            camera.exclusive = GetFastValue(cameraConfig, 'exclusive', false);
 
             // Background Color
 

--- a/src/cameras/2d/typedefs/JSONCamera.js
+++ b/src/cameras/2d/typedefs/JSONCamera.js
@@ -10,6 +10,8 @@
  * @property {number} zoom - The zoom of camera
  * @property {number} rotation - The rotation of camera
  * @property {boolean} roundPixels - The round pixels st status of camera
+ * @property {boolean} visible - Visible of camera
+ * @property {boolean} exclusive - The exclusive flag of camera
  * @property {number} scrollX - The horizontal scroll of camera
  * @property {number} scrollY - The vertical scroll of camera
  * @property {string} backgroundColor - The background color of camera

--- a/src/gameobjects/GameObject.js
+++ b/src/gameobjects/GameObject.js
@@ -174,7 +174,7 @@ var GameObject = new Class({
 
         /**
          * A bitmask that controls if this Game Object is drawn by an exclusive Camera or not.
-         * Not usually set directly, instead call `Camera.accpet`, however you can
+         * Not usually set directly, instead call `Camera.accept`, however you can
          * set this property directly using the Camera.id property:
          *
          * @example

--- a/src/gameobjects/GameObject.js
+++ b/src/gameobjects/GameObject.js
@@ -173,6 +173,21 @@ var GameObject = new Class({
         this.cameraFilter = 0;
 
         /**
+         * A bitmask that controls if this Game Object is drawn by an exclusive Camera or not.
+         * Not usually set directly, instead call `Camera.accpet`, however you can
+         * set this property directly using the Camera.id property:
+         *
+         * @example
+         * this.cameraFilter2 |= camera.id
+         *
+         * @name Phaser.GameObjects.GameObject#cameraFilter2
+         * @type {number}
+         * @default 0
+         * @since 3.60.0
+         */
+        this.cameraFilter2 = 0;
+
+        /**
          * If this Game Object is enabled for input then this property will contain an InteractiveObject instance.
          * Not usually set directly. Instead call `GameObject.setInteractive()`.
          *
@@ -622,7 +637,24 @@ var GameObject = new Class({
     {
         var listWillRender = (this.displayList && this.displayList.active) ? this.displayList.willRender(camera) : true;
 
-        return !(!listWillRender || GameObject.RENDER_MASK !== this.renderFlags || (this.cameraFilter !== 0 && (this.cameraFilter & camera.id)));
+        if (!listWillRender) 
+        {
+            return false;
+        }
+
+        if (GameObject.RENDER_MASK !== this.renderFlags) 
+        {
+            return false;
+        }
+
+        if (!camera.exclusive)
+        {
+            return (this.cameraFilter === 0) || ((this.cameraFilter & camera.id) === 0);
+        }
+        else
+        {
+            return (this.cameraFilter2 !== 0) && ((this.cameraFilter2 & camera.id) !== 0);
+        }
     },
 
     /**


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Exclusive camera will ignore all game objects, only render accepted game objects.

Test code

```javascript
class Demo extends Phaser.Scene {
    constructor() {
        super({
            key: 'examples'
        })
    }

    preload() {
    }

    create() {
        var camera1 = this.cameras.main;

        var camera2 = this.cameras.add(400, 0, 400, 600)
            .setBackgroundColor(0x333333)
            .setExclusive();

        var gameObject0 = this.add.rectangle(200, 100, 100, 100, 0xffffff);
        var gameObject1 = this.add.rectangle(200, 400, 100, 100, 0xffffff);

        camera2.accept(gameObject0);
    }

    update() { }
}

var config = {
    type: Phaser.AUTO,
    parent: 'phaser-example',
    width: 800,
    height: 600,
    scale: {
        mode: Phaser.Scale.FIT,
        autoCenter: Phaser.Scale.CENTER_BOTH,
    },
    scene: Demo
};
```

Put gameObject0 on camera2, so it will only be rendered by camera2. And gameObject1 will only be rendered by camera1. 