### PR TITLE
Fix renderFlags after changing scaleX/scaleY

### DIFF
--- a/src/gameobjects/components/Transform.js
+++ b/src/gameobjects/components/Transform.js
@@ -169,7 +169,7 @@ var Transform = {
             {
                 this.renderFlags &= ~_FLAG;
             }
-            else
+            else if (this._scaleY !== 0)
             {
                 this.renderFlags |= _FLAG;
             }
@@ -200,7 +200,7 @@ var Transform = {
             {
                 this.renderFlags &= ~_FLAG;
             }
-            else
+            else if (this._scaleX !== 0)
             {
                 this.renderFlags |= _FLAG;
             }


### PR DESCRIPTION
The value of renderFlags depends on the order in which scaleX/scaleY changes are made

```js
go.scaleX = 0
go.scaleY = 1
go.renderFlags === 15
```
```js
go.scaleY = 1
go.scaleX = 0
go.renderFlags === 11
```

Because of this, when changing the scale properties in pairs (for example, in a tween), the object passes the willRender check even if one of the scale properties is set to zero
