### PR TITLE
Fix "listener.positionX is undefined" error

### DIFF
--- a/src/sound/webaudio/WebAudioSoundManager.js
+++ b/src/sound/webaudio/WebAudioSoundManager.js
@@ -393,7 +393,7 @@ var WebAudioSoundManager = new Class({
     {
         var listener = this.context.listener;
 
-        if (this.listenerPosition && listener)
+        if (listener && listener.positionX !== undefined)
         {
             listener.positionX.value = this.listenerPosition.x;
             listener.positionY.value = this.listenerPosition.y;


### PR DESCRIPTION
This PR

* Fixes a bug

Fixes #6385

I also removed the `this.listenerPosition` condition because it looks unnecessary.

