### PR TITLE
Adds tileOffset param to Phaser.Tilemaps.Tilemap#addTilesetImage

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -372,11 +372,13 @@ var Tilemap = new Class({
      * If not specified, it will default to 0 or the value specified in the Tiled JSON file.
      * @param {number} [gid=0] - If adding multiple tilesets to a blank map, specify the starting
      * GID this set will use here.
+     * @param {object} [tileOffset={x: 0, y: 0}] - Tile texture drawing offset.
+     * If not specified, it will default to {0, 0}
      *
      * @return {?Phaser.Tilemaps.Tileset} Returns the Tileset object that was created or updated, or null if it
      * failed.
      */
-    addTilesetImage: function (tilesetName, key, tileWidth, tileHeight, tileMargin, tileSpacing, gid)
+    addTilesetImage: function (tilesetName, key, tileWidth, tileHeight, tileMargin, tileSpacing, gid, tileOffset)
     {
         if (tilesetName === undefined) { return null; }
         if (key === undefined || key === null) { key = tilesetName; }
@@ -413,8 +415,9 @@ var Tilemap = new Class({
         if (tileMargin === undefined) { tileMargin = 0; }
         if (tileSpacing === undefined) { tileSpacing = 0; }
         if (gid === undefined) { gid = 0; }
+        if (tileOffset === undefined) { tileOffset = {x: 0, y: 0} }
 
-        tileset = new Tileset(tilesetName, gid, tileWidth, tileHeight, tileMargin, tileSpacing);
+        tileset = new Tileset(tilesetName, gid, tileWidth, tileHeight, tileMargin, tileSpacing, undefined, undefined, tileOffset);
 
         tileset.setImage(texture);
 


### PR DESCRIPTION
This PR
* Adds a new feature
* Fixes a bug
 
Describe the changes below:

Currently addTilesetImage cannot set the tileOffset which means that changing the tileOffset requires you to update each tile after the Tileset is created.

This PR passes the tileOffset through to the Tileset constructor in Phaser.Tilemaps.Tilemap#addTilesetImage
