### PR TITLE
correct the docs for generateFrameNumbers

### DIFF
--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -710,7 +710,7 @@ var AnimationManager = new Class({
      * ```javascript
      * this.anims.create({
      *   key: 'boom',
-     *   frames: this.anims.generateFrameNames('explosion', {
+     *   frames: this.anims.generateFrameNumbers('explosion', {
      *     start: 0,
      *     end: 11
      *   })
@@ -731,7 +731,7 @@ var AnimationManager = new Class({
      * @since 3.0.0
      *
      * @param {string} key - The key for the texture containing the animation frames.
-     * @param {Phaser.Types.Animations.GenerateFrameNumbers} config - The configuration object for the animation frames.
+     * @param {Phaser.Types.Animations.GenerateFrameNumbers} [config] - The configuration object for the animation frames.
      *
      * @return {Phaser.Types.Animations.AnimationFrame[]} The array of {@link Phaser.Types.Animations.AnimationFrame} objects.
      */

--- a/src/animations/AnimationState.js
+++ b/src/animations/AnimationState.js
@@ -1872,16 +1872,16 @@ var AnimationState = new Class({
      * Example:
      *
      * If you have a sprite sheet loaded called `explosion` and it contains 12 frames, then you can call this method using:
-     * `this.anims.generateFrameNumbers('explosion', { start: 0, end: 12 })`.
+     * `this.anims.generateFrameNumbers('explosion', { start: 0, end: 11 })`.
      *
      * The `end` value tells it to stop after 12 frames. To create an animation using this method, you can do:
      *
      * ```javascript
      * this.anims.create({
      *   key: 'boom',
-     *   frames: this.anims.generateFrameNames('explosion', {
+     *   frames: this.anims.generateFrameNumbers('explosion', {
      *     start: 0,
-     *     end: 12
+     *     end: 11
      *   })
      * });
      * ```
@@ -1900,7 +1900,7 @@ var AnimationState = new Class({
      * @since 3.50.0
      *
      * @param {string} key - The key for the texture containing the animation frames.
-     * @param {Phaser.Types.Animations.GenerateFrameNumbers} config - The configuration object for the animation frames.
+     * @param {Phaser.Types.Animations.GenerateFrameNumbers} [config] - The configuration object for the animation frames.
      *
      * @return {Phaser.Types.Animations.AnimationFrame[]} The array of {@link Phaser.Types.Animations.AnimationFrame} objects.
      */


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:

1. the function used in the example should be `this.anims.generateFrameNumbers` instead of `this.anims.generateFrameNames`.
2. the end frame in the example should be `11` instead of `12` (see https://github.com/photonstorm/phaser/commit/6761ec92f5c95d5e736c22cf4b3d3bb248b1ad90).
3. mark the "config" parameter as optional (the one for `generateFrameNames` is already marked as optional).

