### PR TITLE
Fix error stopping a scene without a loader

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -1296,8 +1296,11 @@ var SceneManager = new Class({
         {
             var loader = scene.sys.load;
 
-            loader.off(LoaderEvents.COMPLETE, this.loadComplete, this);
-            loader.off(LoaderEvents.COMPLETE, this.payloadComplete, this);
+            if (loader)
+            {
+                loader.off(LoaderEvents.COMPLETE, this.loadComplete, this);
+                loader.off(LoaderEvents.COMPLETE, this.payloadComplete, this);
+            }
 
             scene.sys.shutdown(data);
         }


### PR DESCRIPTION
This PR

* Fixes a bug (v3.60.0-beta.6)

Shutting down a scene without a LoaderPlugin would cause an error.

https://github.com/photonstorm/phaser/commit/0679f1aa649ee2c8eddf03ae94f09d3603b140ce



