### PR TITLE
Support staggeraxis-x, staggerindex-odd

### DIFF
--- a/src/tilemaps/Tile.js
+++ b/src/tilemaps/Tile.js
@@ -781,19 +781,36 @@ var Tile = new Class({
             var len = this.layer.hexSideLength;
 
             var rowWidth, rowHeight;
-            if ((staggerAxis === 'y') && (staggerIndex === 'odd'))
+            if (staggerAxis === 'y')
             {
                 rowHeight = ((this.baseHeight - len) / 2 + len);
 
-                this.pixelX = this.x * this.baseWidth + this.y % 2 * (this.baseWidth / 2);
+                if (staggerIndex === 'odd')
+                {
+                    this.pixelX = this.x * this.baseWidth + this.y % 2 * (this.baseWidth / 2);
+                }
+                else
+                {
+                    this.pixelX = this.x * this.baseWidth - this.y % 2 * (this.baseWidth / 2);
+                }
+                
                 this.pixelY = this.y * rowHeight;
             }
-            else if ((staggerAxis === 'x') && (staggerIndex === 'odd'))
+            else if (staggerAxis === 'x')
             {
                 rowWidth = ((this.baseWidth - len) / 2 + len);
 
                 this.pixelX = this.x * rowWidth;
-                this.pixelY = this.y * this.baseHeight + this.x % 2 * (this.baseHeight / 2);
+
+                if (staggerIndex === 'odd')
+                {
+                    this.pixelY = this.y * this.baseHeight + this.x % 2 * (this.baseHeight / 2);
+                }
+                else
+                {
+                    this.pixelY = this.y * this.baseHeight - this.x % 2 * (this.baseHeight / 2);
+                }
+                
             }
 
         }

--- a/src/tilemaps/Tile.js
+++ b/src/tilemaps/Tile.js
@@ -776,11 +776,26 @@ var Tile = new Class({
         }
         else if (orientation === CONST.HEXAGONAL)
         {
+            var staggerAxis = this.layer.staggerAxis;
+            var staggerIndex = this.layer.staggerIndex;
             var len = this.layer.hexSideLength;
-            var rowHeight = ((this.baseHeight - len) / 2 + len);
 
-            this.pixelX = this.x * this.baseWidth + this.y % 2 * (this.baseWidth / 2);
-            this.pixelY = this.y * rowHeight;
+            var rowWidth, rowHeight;
+            if ((staggerAxis === 'y') && (staggerIndex === 'odd'))
+            {
+                rowHeight = ((this.baseHeight - len) / 2 + len);
+
+                this.pixelX = this.x * this.baseWidth + this.y % 2 * (this.baseWidth / 2);
+                this.pixelY = this.y * rowHeight;
+            }
+            else if ((staggerAxis === 'x') && (staggerIndex === 'odd'))
+            {
+                rowWidth = ((this.baseWidth - len) / 2 + len);
+
+                this.pixelX = this.x * rowWidth;
+                this.pixelY = this.y * this.baseHeight + this.x % 2 * (this.baseHeight / 2);
+            }
+
         }
 
         this.right = this.pixelX + this.baseWidth;

--- a/src/tilemaps/components/HexagonalCullBounds.js
+++ b/src/tilemaps/components/HexagonalCullBounds.js
@@ -31,13 +31,28 @@ var HexagonalCullBounds = function (layer, camera)
     var tileH = Math.floor(tilemap.tileHeight * tilemapLayer.scaleY);
 
     var len = layer.hexSideLength;
-    var rowH = ((tileH - len) / 2 + len);
+    var boundsLeft, boundsRight, boundsTop, boundsBottom;
+    if (this.staggerAxis === 'y')
+    {
+        var rowH = ((tileH - len) / 2 + len);
+    
+        boundsLeft = SnapFloor(camera.worldView.x - tilemapLayer.x, tileW, 0, true) - tilemapLayer.cullPaddingX;
+        boundsRight = SnapCeil(camera.worldView.right - tilemapLayer.x, tileW, 0, true) + tilemapLayer.cullPaddingX;
+    
+        boundsTop = SnapFloor(camera.worldView.y - tilemapLayer.y, rowH, 0, true) - tilemapLayer.cullPaddingY;
+        boundsBottom = SnapCeil(camera.worldView.bottom - tilemapLayer.y, rowH, 0, true) + tilemapLayer.cullPaddingY;
+    }
+    else
+    {
+        var rowW = ((tileW - len) / 2 + len);
+    
+        boundsLeft = SnapFloor(camera.worldView.x - tilemapLayer.x, rowW, 0, true) - tilemapLayer.cullPaddingX;
+        boundsRight = SnapCeil(camera.worldView.right - tilemapLayer.x, rowW, 0, true) + tilemapLayer.cullPaddingX;
+    
+        boundsTop = SnapFloor(camera.worldView.y - tilemapLayer.y, tileH, 0, true) - tilemapLayer.cullPaddingY;
+        boundsBottom = SnapCeil(camera.worldView.bottom - tilemapLayer.y, tileH, 0, true) + tilemapLayer.cullPaddingY;
+    }
 
-    var boundsLeft = SnapFloor(camera.worldView.x - tilemapLayer.x, tileW, 0, true) - tilemapLayer.cullPaddingX;
-    var boundsRight = SnapCeil(camera.worldView.right - tilemapLayer.x, tileW, 0, true) + tilemapLayer.cullPaddingX;
-
-    var boundsTop = SnapFloor(camera.worldView.y - tilemapLayer.y, rowH, 0, true) - tilemapLayer.cullPaddingY;
-    var boundsBottom = SnapCeil(camera.worldView.bottom - tilemapLayer.y, rowH, 0, true) + tilemapLayer.cullPaddingY;
 
     return {
         left: boundsLeft,

--- a/src/tilemaps/components/HexagonalGetTileCorners.js
+++ b/src/tilemaps/components/HexagonalGetTileCorners.js
@@ -42,8 +42,17 @@ var HexagonalGetTileCorners = function (tileX, tileY, camera, layer)
     //  Hard-coded orientation values for Pointy-Top Hexagons only
     var b0 = 0.5773502691896257; // Math.sqrt(3) / 3
 
-    var hexWidth = b0 * tileWidth;
-    var hexHeight = tileHeight / 2;
+    var hexWidth, hexHeight;
+    if (this.staggerAxis === 'y')
+    {
+        hexWidth = b0 * tileWidth;
+        hexHeight = tileHeight / 2;
+    }
+    else
+    {
+        hexWidth = tileWidth / 2;
+        hexHeight = b0 * tileHeight;
+    }
 
     for (var i = 0; i < 6; i++)
     {

--- a/src/tilemaps/components/HexagonalTileToWorldXY.js
+++ b/src/tilemaps/components/HexagonalTileToWorldXY.js
@@ -50,13 +50,30 @@ var HexagonalTileToWorldXY = function (tileX, tileY, point, camera, layer)
     var tileWidthHalf = tileWidth / 2;
     var tileHeightHalf = tileHeight / 2;
 
-    var x = worldX + (tileWidth * tileX) + tileWidth;
-    var y = worldY + ((1.5 * tileY) * tileHeightHalf) + tileHeightHalf;
+    var x, y;
 
-    if (tileY % 2 === 0)
+    if ((this.staggerAxis === 'y') && (this.staggerIndex === 'odd'))
     {
-        x -= tileWidthHalf;
+        x = worldX + (tileWidth * tileX) + tileWidth;
+        y = worldY + ((1.5 * tileY) * tileHeightHalf) + tileHeightHalf;
+    
+        if (tileY % 2 === 0)
+        {
+            x -= tileWidthHalf;
+        }
     }
+    else if ((this.staggerAxis === 'x') && (this.staggerIndex === 'odd'))
+    {
+        x = worldX + ((1.5 * tileX) * tileWidthHalf) + tileWidthHalf;
+        y = worldY + (tileHeight * tileX) + tileHeight;
+    
+        if (tileX % 2 === 0)
+        {
+            y -= tileHeightHalf;
+        }
+    }
+
+
 
     return point.set(x, y);
 };

--- a/src/tilemaps/components/HexagonalTileToWorldXY.js
+++ b/src/tilemaps/components/HexagonalTileToWorldXY.js
@@ -52,14 +52,21 @@ var HexagonalTileToWorldXY = function (tileX, tileY, point, camera, layer)
 
     var x, y;
 
-    if ((this.staggerAxis === 'y') && (this.staggerIndex === 'odd'))
+    if (this.staggerAxis === 'y')
     {
         x = worldX + (tileWidth * tileX) + tileWidth;
         y = worldY + ((1.5 * tileY) * tileHeightHalf) + tileHeightHalf;
     
         if (tileY % 2 === 0)
         {
-            x -= tileWidthHalf;
+            if (this.staggerIndex === 'odd')
+            {
+                x -= tileWidthHalf;
+            }
+            else
+            {
+                x += tileWidthHalf;
+            }            
         }
     }
     else if ((this.staggerAxis === 'x') && (this.staggerIndex === 'odd'))
@@ -69,7 +76,15 @@ var HexagonalTileToWorldXY = function (tileX, tileY, point, camera, layer)
     
         if (tileX % 2 === 0)
         {
-            y -= tileHeightHalf;
+            if (this.staggerIndex === 'odd') 
+            {
+                y -= tileHeightHalf;
+            }
+            else
+            {
+                y += tileHeightHalf;
+            }
+            
         }
     }
 

--- a/src/tilemaps/components/HexagonalWorldToTileXY.js
+++ b/src/tilemaps/components/HexagonalWorldToTileXY.js
@@ -55,15 +55,32 @@ var HexagonalWorldToTileXY = function (worldX, worldY, snapToFloor, point, camer
     var tileWidthHalf = tileWidth / 2;
     var tileHeightHalf = tileHeight / 2;
 
-    //  size
-    //  x = b0 * tileWidth
-    //  y = tileHeightHalf
-    var px = (worldX - tileWidthHalf) / (b0 * tileWidth);
-    var py = (worldY - tileHeightHalf) / tileHeightHalf;
+    var px, py;
+    var q, r, s;
 
-    var q = b0 * px + b1 * py;
-    var r = b2 * px + b3 * py;
-    var s = -q - r;
+    //  size
+    if (this.staggerAxis === 'y')
+    {
+        //  x = b0 * tileWidth
+        //  y = tileHeightHalf
+        px = (worldX - tileWidthHalf) / (b0 * tileWidth);
+        py = (worldY - tileHeightHalf) / tileHeightHalf;
+
+        q = b0 * px + b1 * py;
+        r = b2 * px + b3 * py;
+    }
+    else
+    {
+        //  x = tileWidthHalf
+        //  y = b0 * tileHeight
+        px = (worldX - tileWidthHalf) / tileWidthHalf;
+        py = (worldY - tileHeightHalf) / (b0 * tileHeight);
+
+        q = b1 * px + b0 * py;
+        r = b3 * px + b2 * py;
+    }
+    
+    s = -q - r;
 
     var qi = Math.round(q);
     var ri = Math.round(r);
@@ -84,7 +101,6 @@ var HexagonalWorldToTileXY = function (worldX, worldY, snapToFloor, point, camer
 
     var y = ri;
 
-    //  odd-r implementation:
     var x = (y % 2 === 0) ? (ri / 2) + qi : (ri / 2) + qi - 0.5;
 
     return point.set(x, y);

--- a/src/tilemaps/components/HexagonalWorldToTileXY.js
+++ b/src/tilemaps/components/HexagonalWorldToTileXY.js
@@ -59,7 +59,7 @@ var HexagonalWorldToTileXY = function (worldX, worldY, snapToFloor, point, camer
     var q, r, s;
 
     //  size
-    if (this.staggerAxis === 'y')
+    if (layer.staggerAxis === 'y')
     {
         //  x = b0 * tileWidth
         //  y = tileHeightHalf
@@ -99,9 +99,18 @@ var HexagonalWorldToTileXY = function (worldX, worldY, snapToFloor, point, camer
         ri = -qi - si;
     }
 
-    var y = ri;
+    var x, y;
 
-    var x = (y % 2 === 0) ? (ri / 2) + qi : (ri / 2) + qi - 0.5;
+    y = ri;
+
+    if (layer.staggerIndex === 'odd')
+    {
+        x = (y % 2 === 0) ? (ri / 2) + qi : (ri / 2) + qi - 0.5;
+    }
+    else
+    {
+        x = (y % 2 === 0) ? (ri / 2) + qi : (ri / 2) + qi + 0.5;
+    }
 
     return point.set(x, y);
 };

--- a/src/tilemaps/mapdata/LayerData.js
+++ b/src/tilemaps/mapdata/LayerData.js
@@ -227,6 +227,30 @@ var LayerData = new Class({
          * @since 3.50.0
          */
         this.hexSideLength = GetFastValue(config, 'hexSideLength', 0);
+        
+        /**
+         * The Stagger Axis as defined in Tiled.
+         *
+         * Only used for hexagonal orientation Tilemaps.
+         *
+         * @name Phaser.Tilemaps.MapData#staggerAxis
+         * @type {string}
+         * @since 3.60.0
+         */
+        this.staggerAxis = GetFastValue(config, 'staggerAxis', 'y');
+
+        /**
+         * The Stagger Index as defined in Tiled.
+         *
+         * Either 'odd' or 'even'.
+         *
+         * Only used for hexagonal orientation Tilemaps.
+         *
+         * @name Phaser.Tilemaps.MapData#staggerIndex
+         * @type {string}
+         * @since 3.60.0
+         */
+        this.staggerIndex = GetFastValue(config, 'staggerIndex', 'odd');
     }
 
 });

--- a/src/tilemaps/parsers/tiled/ParseTileLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseTileLayers.js
@@ -137,6 +137,8 @@ var ParseTileLayers = function (json, insertNull)
             if (layerData.orientation === CONST.HEXAGONAL)
             {
                 layerData.hexSideLength = json.hexsidelength;
+                layerData.staggerAxis = json.staggeraxis;
+                layerData.staggerIndex = json.staggerindex;
             }
 
             for (var c = 0; c < curl.height; c++)
@@ -215,6 +217,8 @@ var ParseTileLayers = function (json, insertNull)
             if (layerData.orientation === CONST.HEXAGONAL)
             {
                 layerData.hexSideLength = json.hexsidelength;
+                layerData.staggerAxis = json.staggeraxis;
+                layerData.staggerIndex = json.staggerindex;
             }
             var row = [];
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Hexagon has 4 kinds of layout setting in tiled

- staggeraxis-y, staggerindex-odd
- staggeraxis-x, staggerindex-odd
- staggeraxis-y, staggerindex-even
- staggeraxis-x, staggerindex-even

Currently, p3 supports staggeraxis-y, staggerindex-odd. This PR try to support staggeraxis-x, staggerindex-odd (#6326).