### PR TITLE
Change GetBounds() default output type to Rectangle

### DIFF
--- a/src/display/bounds/GetBounds.js
+++ b/src/display/bounds/GetBounds.js
@@ -8,6 +8,7 @@ var GetBottom = require('./GetBottom');
 var GetLeft = require('./GetLeft');
 var GetRight = require('./GetRight');
 var GetTop = require('./GetTop');
+var Rectangle = require('../../geom/rectangle/Rectangle');
 
 /**
  * Returns the unrotated bounds of the Game Object as a rectangle.
@@ -16,13 +17,13 @@ var GetTop = require('./GetTop');
  * @since 3.24.0
  *
  * @param {Phaser.GameObjects.GameObject} gameObject - The Game Object to get the bounds value from.
- * @param {(Phaser.Geom.Rectangle|object)} [output] - An object to store the values in.
+ * @param {(Phaser.Geom.Rectangle|object)} [output] - An object to store the values in. If not provided a new Rectangle will be created.
  *
  * @return {(Phaser.Geom.Rectangle|object)} - The bounds of the Game Object.
  */
 var GetBounds = function (gameObject, output)
 {
-    if (output === undefined) { output = {}; }
+    if (output === undefined) { output = new Rectangle(); }
 
     var left = GetLeft(gameObject);
     var top = GetTop(gameObject);


### PR DESCRIPTION
This PR

* Adds a new feature

This is more consistent with the rest of the API, IMO.

