### PR TITLE
Fix putTileAt() with empty tile

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -4,6 +4,7 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
+var BuildTilesetIndex = require('./parsers/tiled/BuildTilesetIndex');
 var Class = require('../utils/Class');
 var DegToRad = require('../math/DegToRad');
 var Formats = require('./Formats');
@@ -245,6 +246,16 @@ var Tilemap = new Class({
         this.layers = mapData.layers;
 
         /**
+         * Master list of tiles -> x, y, index in tileset.
+         *
+         * @name Phaser.Tilemaps.Tilemap#tiles
+         * @type {array}
+         * @since 3.60.0
+         * @see Phaser.Tilemaps.Parsers.Tiled.BuildTilesetIndex
+         */
+        this.tiles = mapData.tiles;
+
+        /**
          * An array of Tilesets used in the map.
          *
          * @name Phaser.Tilemaps.Tilemap#tilesets
@@ -419,6 +430,8 @@ var Tilemap = new Class({
         tileset.setImage(texture);
 
         this.tilesets.push(tileset);
+
+        this.tiles = BuildTilesetIndex(this);
 
         return tileset;
     },

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -2666,6 +2666,7 @@ var Tilemap = new Class({
     {
         this.removeAllLayers();
 
+        this.tiles.length = 0;
         this.tilesets.length = 0;
         this.objects.length = 0;
 

--- a/src/tilemaps/components/PutTileAt.js
+++ b/src/tilemaps/components/PutTileAt.js
@@ -8,7 +8,6 @@ var Tile = require('../Tile');
 var IsInLayerBounds = require('./IsInLayerBounds');
 var CalculateFacesAt = require('./CalculateFacesAt');
 var SetTileCollision = require('./SetTileCollision');
-var BuildTilesetIndex = require('../parsers/tiled/BuildTilesetIndex');
 
 /**
  * Puts a tile at the given tile coordinates in the specified layer. You can pass in either an index
@@ -67,16 +66,22 @@ var PutTileAt = function (tile, tileX, tileY, recalculateFaces, layer)
     var newTile = layer.data[tileY][tileX];
     var collides = layer.collideIndexes.indexOf(newTile.index) !== -1;
 
-    // Copy properties from tileset to tiles.
-    var tiles = BuildTilesetIndex(layer.tilemapLayer.tilemap);
-
     index = tile instanceof Tile ? tile.index : tile;
 
-    var sid = tiles[index][2];
-    var set = layer.tilemapLayer.tileset[sid];
+    if (index === -1)
+    {
+        newTile.width = layer.tileWidth;
+        newTile.height = layer.tileHeight;
+    }
+    else
+    {
+        var tiles = layer.tilemapLayer.tilemap.tiles;
+        var sid = tiles[index][2];
+        var set = layer.tilemapLayer.tileset[sid];
 
-    newTile.width = set.tileWidth;
-    newTile.height = set.tileHeight;
+        newTile.width = set.tileWidth;
+        newTile.height = set.tileHeight;
+    }
 
     SetTileCollision(newTile, collides);
 


### PR DESCRIPTION
This PR

* Fixes a bug

Fixes #6353.

Adds `Phaser.Tilemaps.Tilemap#tiles`, avoiding calling `BuildTilesetIndex()` for each put tile.



