### PR TITLE
Add `skipBatch` in StampConfig parameter of stamp method

### DIFF
--- a/src/textures/DynamicTexture.js
+++ b/src/textures/DynamicTexture.js
@@ -450,6 +450,7 @@ var DynamicTexture = new Class({
         var originY = GetFastValue(config, 'originY', 0.5);
         var blendMode = GetFastValue(config, 'blendMode', 0);
         var erase = GetFastValue(config, 'erase', false);
+        var skipBatch = GetFastValue(config, 'skipBatch', false);
 
         var stamp = this.manager.resetStamp(alpha, tint);
 
@@ -474,7 +475,15 @@ var DynamicTexture = new Class({
             this._eraseMode = true;
         }
 
-        this.draw(stamp, x, y);
+        if (!skipBatch)
+        {
+            this.draw(stamp, x, y);
+        }
+        else
+        {
+            this.batchDraw(stamp, x, y)
+        }
+        
 
         if (erase)
         {

--- a/src/textures/typedefs/StampConfig.js
+++ b/src/textures/typedefs/StampConfig.js
@@ -15,4 +15,5 @@
  * @property {number} [originY=0.5] - The vertical origin of the stamp. 0 is the top, 0.5 is the center and 1 is the bottom.
  * @property {(string|Phaser.BlendModes|number)} [blendMode=0] - The blend mode used when drawing the stamp. Defaults to 0 (normal).
  * @property {boolean} [erase=false] - Erase this stamp from the texture?
+ * @property {boolean} [skipBatch=false] - Skip beginning and ending a batch with this call. Use if this is part of a bigger batched draw.
  */


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Method `stamp` and `repeat` can draw a single frame or repeat frames. 
`repeat` has `skipBatch` parameter, but `stamp` does not, so I add `skipBatch` into StampConfig of  `stamp` method.

(BTW, method `draw` has *skipBatch* version `batchDraw`.)