### PR TITLE
reverted using getTextBounds for cotainer getBounds()

### DIFF
--- a/src/gameobjects/container/Container.js
+++ b/src/gameobjects/container/Container.js
@@ -407,28 +407,19 @@ var Container = new Class({
             {
                 var entry = children[i];
 
-                if (entry.getTextBounds)
-                {
-                    var textBounds = entry.getTextBounds().global;
-                    tempRect.setTo(textBounds.x, textBounds.y, textBounds.width, textBounds.height);
-                }
-                else if (entry.getBounds)
+                if (entry.getBounds)
                 {
                     entry.getBounds(tempRect);
-                }
-                else
-                {
-                    continue;
-                }
 
-                if (!hasSetFirst)
-                {
-                    output.setTo(tempRect.x, tempRect.y, tempRect.width, tempRect.height);
-                    hasSetFirst = true;
-                }
-                else
-                {
-                    Union(tempRect, output, output);
+                    if (!hasSetFirst)
+                    {
+                        output.setTo(tempRect.x, tempRect.y, tempRect.width, tempRect.height);
+                        hasSetFirst = true;
+                    }
+                    else
+                    {
+                        Union(tempRect, output, output);
+                    }
                 }
             }
         }


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:
#6384
was leading to bugs #6398

I made container use getTextBounds() based on a fix for my own game.
But my game that was using an old version of the phaser 3.60 beta before BitmapText had its own getBounds() 6943989
I did some test and my change #6384 was unnecessary as commit 6943989 already solved my original problems.
I should have tested more before made the pull request
