### PR TITLE
fix: memory leak in WebAudioSoundManager

### DIFF
--- a/src/sound/webaudio/WebAudioSoundManager.js
+++ b/src/sound/webaudio/WebAudioSoundManager.js
@@ -314,7 +314,7 @@ var WebAudioSoundManager = new Class({
         {
             if (_this.context && body)
             {
-                var bodyRemove = body.removeEventListener;
+                var bodyRemove = body.removeEventListener.bind(body);
 
                 _this.context.resume().then(function ()
                 {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

`unlockHandler` was not removed because `this` was not binded to `bodyRemove` function, causing serious memory leak. As you see performance debugger with chrome, event listeners count get continuously increased as user presses keyboard.

This fixes the above bug by binding `document.body` to `bodyRemove` function.