### PR TITLE
BitmapText now reset texture unit on flush

### DIFF
--- a/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextWebGLRenderer.js
+++ b/src/gameobjects/bitmaptext/dynamic/DynamicBitmapTextWebGLRenderer.js
@@ -267,6 +267,12 @@ var DynamicBitmapTextWebGLRenderer = function (renderer, src, camera, parentMatr
             ty3 = Math.round(ty3);
         }
 
+        if (pipeline.shouldFlush(6))
+        {
+            pipeline.flush();
+            textureUnit = pipeline.setGameObject(src);
+        }
+
         pipeline.batchQuad(src, tx0, ty0, tx1, ty1, tx2, ty2, tx3, ty3, u0, v0, u1, v1, tintTL, tintTR, tintBL, tintBR, tintEffect, texture, textureUnit);
     }
 

--- a/src/gameobjects/bitmaptext/static/BitmapTextWebGLRenderer.js
+++ b/src/gameobjects/bitmaptext/static/BitmapTextWebGLRenderer.js
@@ -107,6 +107,12 @@ var BitmapTextWebGLRenderer = function (renderer, src, camera, parentMatrix)
             continue;
         }
 
+        if (pipeline.shouldFlush(6))
+        {
+            pipeline.flush();
+            textureUnit = pipeline.setGameObject(src);
+        }
+
         if (charColors[char.i])
         {
             var color = charColors[char.i];


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:
When a flush happen while BitmapText / DynamicBitmapText is rendering characters  the textureUint was not update.
