### PR TITLE
Fixes drawing hexagonal tilemaps

### DIFF
--- a/src/tilemaps/components/HexagonalCullBounds.js
+++ b/src/tilemaps/components/HexagonalCullBounds.js
@@ -37,7 +37,7 @@ var HexagonalCullBounds = function (layer, camera)
     var boundsTop;
     var boundsBottom;
 
-    if (this.staggerAxis === 'y')
+    if (layer.staggerAxis === 'y')
     {
         var rowH = ((tileH - len) / 2 + len);
 

--- a/src/tilemaps/components/HexagonalGetTileCorners.js
+++ b/src/tilemaps/components/HexagonalGetTileCorners.js
@@ -45,7 +45,7 @@ var HexagonalGetTileCorners = function (tileX, tileY, camera, layer)
     var hexWidth;
     var hexHeight;
 
-    if (this.staggerAxis === 'y')
+    if (layer.staggerAxis === 'y')
     {
         hexWidth = b0 * tileWidth;
         hexHeight = tileHeight / 2;

--- a/src/tilemaps/components/HexagonalTileToWorldXY.js
+++ b/src/tilemaps/components/HexagonalTileToWorldXY.js
@@ -53,7 +53,7 @@ var HexagonalTileToWorldXY = function (tileX, tileY, point, camera, layer)
     var x;
     var y;
 
-    if (this.staggerAxis === 'y')
+    if (layer.staggerAxis === 'y')
     {
         x = worldX + (tileWidth * tileX) + tileWidth;
         y = worldY + ((1.5 * tileY) * tileHeightHalf) + tileHeightHalf;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
Changed this. for a layer which holds the staggerAxis property. Without this change the hexagonal tilemaps (tested only from Tiled) are not rendering and throwing the following error
![image](https://user-images.githubusercontent.com/31895316/235499046-13cb20f6-f505-4e76-9c1a-47906815dcd5.png)


