### PR TITLE
avoid TypeError in addSpriteSheet method of TextureManager

### DIFF
--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -1058,7 +1058,7 @@ var TextureManager = new Class({
 
         if (source instanceof Texture)
         {
-            key = texture.key;
+            key = source.key;
             texture = source;
         }
         else if (this.checkKey(key))


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The variable `texture` is set to null on line 1057.   On 1061 we attempt to read its `key` property which is not available, throwing a TypeError.  Instead we can use the key from the source argument as documented on line 1048.
