### PR TITLE
add proper key value to scale width and height

### DIFF
--- a/src/core/Config.js
+++ b/src/core/Config.js
@@ -94,32 +94,42 @@ var Config = new Class({
         /**
          * @const {number} Phaser.Core.Config#resizeInterval - How many ms should elapse before checking if the browser size has changed?
          */
-        this.resizeInterval = GetValue(scaleConfig, 'resizeInterval', 500, config);
+        this.resizeInterval = GetValue(
+            scaleConfig,
+            'resizeInterval',
+            500,
+            config
+        );
 
         /**
          * @const {?(HTMLElement|string)} Phaser.Core.Config#fullscreenTarget - The DOM element that will be sent into full screen mode, or its `id`. If undefined Phaser will create its own div and insert the canvas into it when entering fullscreen mode.
          */
-        this.fullscreenTarget = GetValue(scaleConfig, 'fullscreenTarget', null, config);
+        this.fullscreenTarget = GetValue(
+            scaleConfig,
+            'fullscreenTarget',
+            null,
+            config
+        );
 
         /**
          * @const {number} Phaser.Core.Config#minWidth - The minimum width, in pixels, the canvas will scale down to. A value of zero means no minimum.
          */
-        this.minWidth = GetValue(scaleConfig, 'minWidth', 0, config);
+        this.minWidth = GetValue(scaleConfig, 'min.width', 0, config);
 
         /**
          * @const {number} Phaser.Core.Config#maxWidth - The maximum width, in pixels, the canvas will scale up to. A value of zero means no maximum.
          */
-        this.maxWidth = GetValue(scaleConfig, 'maxWidth', 0, config);
+        this.maxWidth = GetValue(scaleConfig, 'max.width', 0, config);
 
         /**
          * @const {number} Phaser.Core.Config#minHeight - The minimum height, in pixels, the canvas will scale down to. A value of zero means no minimum.
          */
-        this.minHeight = GetValue(scaleConfig, 'minHeight', 0, config);
+        this.minHeight = GetValue(scaleConfig, 'min.height', 0, config);
 
         /**
          * @const {number} Phaser.Core.Config#maxHeight - The maximum height, in pixels, the canvas will scale up to. A value of zero means no maximum.
          */
-        this.maxHeight = GetValue(scaleConfig, 'maxHeight', 0, config);
+        this.maxHeight = GetValue(scaleConfig, 'max.height', 0, config);
 
         /**
          * @const {number} Phaser.Core.Config#renderType - Force Phaser to use a specific renderer. Can be `CONST.CANVAS`, `CONST.WEBGL`, `CONST.HEADLESS` or `CONST.AUTO` (default)


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
This should fix the bug described here:
https://github.com/photonstorm/phaser/issues/6501

When getting the `scale` from the config object, we're currently not getting the proper key. This PR introduces getting `min.width, min.height, max.width, max.height`
