### PR TITLE
Added physics world singleStep method.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phaser",
-  "version": "3.60.0",
+  "version": "3.60.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phaser",
-      "version": "3.60.0",
+      "version": "3.60.1",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.0"

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1009,6 +1009,21 @@ var World = new Class({
     },
 
     /**
+     * Advances the simulation by a single step.
+     *
+     * @method Phaser.Physics.Arcade.World#step
+     * @fires Phaser.Physics.Arcade.Events#WORLD_STEP
+     * @since 3.60.1
+     *
+     * @param {number} delta - The delta time amount, in seconds, by which to advance the simulation.
+     */
+    singleStep: function ()
+    {
+        this.update(0, this._frameTimeMS);
+        this.postUpdate();
+    },
+
+    /**
      * Advances the simulation by a time increment.
      *
      * @method Phaser.Physics.Arcade.World#step


### PR DESCRIPTION
This PR

* Updates the Documentation
* Adds a new feature

Describe the changes below:

The `physics.world.step` method does not work as expected. [Look this discussion on Discourse](https://phaser.discourse.group/t/how-to-pre-calculate-a-physics-simulation/13347).

## Example Test Code

<!--
All issues must have source code demonstrating the problem. We automatically close issues after 30 days if no code is provided.

The code can be pasted directly below this comment, or you can link to codepen, jsbin, or similar. The code will ideally be runnable instantly. The more work involved in turning your code into a reproducible test case, the longer it will take the fix the issue.
-->

```js
		this.visible = true;
		const xPositions = [];
		const yPositions = [];

		this.reset();
		this.body.setAllowGravity(true);
		this.body.setVelocityX(200);
		this.body.setVelocityY(200);

		console.log(`customUpdate is ${scnGame.physics.config.customUpdate}`);

		if (scnGame.physics.config.customUpdate) {
			const { world } = scnGame.physics;

			const delta = world._frameTime;

			for (let i = 0; i < 100; i++) {
				world.step(delta);
				xPositions.push(Math.round(this.body.x));
				yPositions.push(Math.round(this.body.y));
			}

			console.log({
				x: xPositions,
				y: yPositions,
			});
		} else {
			const updateHandler = () => {
				xPositions.push(Math.round(this.x));
				yPositions.push(Math.round(this.y));

				if (xPositions.length === 100) {
					console.log({
						x: xPositions,
						y: yPositions,
					});
				}
			};
			scnGame.events.on("update", updateHandler);
		}
```

The resulting arrays (`xPositions` and `yPositions`) are completely different.

Thanks to @samme , found out that the correct way to perform a single step in the physics world is:

world.update(0, world._frameTimeMS);
world.postUpdate();
