### PR TITLE
Timeline restart method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phaser",
-  "version": "3.60.0",
+  "version": "3.60.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phaser",
-      "version": "3.60.0",
+      "version": "3.60.1",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.0"

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1009,6 +1009,21 @@ var World = new Class({
     },
 
     /**
+     * Advances the simulation by a single step.
+     *
+     * @method Phaser.Physics.Arcade.World#step
+     * @fires Phaser.Physics.Arcade.Events#WORLD_STEP
+     * @since 3.60.1
+     *
+     * @param {number} delta - The delta time amount, in seconds, by which to advance the simulation.
+     */
+    singleStep: function ()
+    {
+        this.update(0, this._frameTimeMS);
+        this.postUpdate();
+    },
+
+    /**
      * Advances the simulation by a time increment.
      *
      * @method Phaser.Physics.Arcade.World#step

--- a/src/time/Timeline.js
+++ b/src/time/Timeline.js
@@ -449,6 +449,23 @@ var Timeline = new Class({
     },
 
     /**
+     * Restarts this Timeline from the beginning.
+     *
+     * This method resets the elapsed time to zero and sets all events to be incomplete.
+     * It is equivalent to calling `reset` followed by `play`.
+     *
+     * @method Phaser.Time.Timeline#restart
+     * @since 3.60.1
+     *
+     * @return {this} This Timeline instance.
+     */
+    restart: function ()
+    {
+        this.reset();
+        return this.play();
+    },
+
+    /**
      * Adds one or more events to this Timeline.
      *
      * You can pass in a single configuration object, or an array of them:


### PR DESCRIPTION
This PR

* Updates the Documentation
* Adds a new feature

Describe the changes below:

# Pull Request: Restart Method for Timeline Object

## Description
This pull request adds a new method called `restart` to the Timeline object. The `restart` method resets the timeline back to the start by setting the elapsed time to zero and marking all events as incomplete. After resetting, the timeline is automatically started by calling the `play` method.

## Motivation
The addition of the `restart` method provides a convenient way to reset and restart a timeline without needing to call separate methods. This improves the usability and readability of the Timeline object.

## Changes Made
- Added a new method `restart` to the Timeline object.
- The `restart` method resets the elapsed time to zero.
- All events in the timeline are marked as incomplete.
- The `restart` method calls the `reset` method to handle the reset logic.
- After resetting, the timeline is automatically started by calling the `play` method.

## Usage Example
```javascript
const timeline = this.add.timeline();

// Add timeline events...

timeline.restart();
