### PR TITLE
Apply AnimationManager's global time scale to AnimationStates.

### DIFF
--- a/src/animations/AnimationState.js
+++ b/src/animations/AnimationState.js
@@ -1487,7 +1487,7 @@ var AnimationState = new Class({
             return;
         }
 
-        this.accumulator += delta * this.timeScale;
+        this.accumulator += delta * this.timeScale * this.animationManager.globalTimeScale;
 
         if (this._pendingStop === 1)
         {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature(?)

Describe the changes below:

AnimationManager has a property `globalTimeScale`, but as far as I can tell it's not used outside of `fromJSON` and `toJSON`. Instead, the only way (that I can find) to globally speed up and slow down animations is to modify every game object's `anims.timeScale`.

This updates animations to match what tweens do: The local time scale is multiplied by the parent time scale so that a change to either will affect the speed of things.