### PR TITLE
Expose layer id from Tiled map parser in LayerData and ObjectLayer

### DIFF
--- a/src/tilemaps/mapdata/LayerData.js
+++ b/src/tilemaps/mapdata/LayerData.js
@@ -39,6 +39,15 @@ var LayerData = new Class({
         this.name = GetFastValue(config, 'name', 'layer');
 
         /**
+         * The id of the layer, as specified in the map data, NOT the index.
+         * 
+         * @name Phaser.Tilemaps.LayerData#id
+         * @type {number}
+         * @since 3.60.1
+         */
+        this.id = GetFastValue(config, 'id', 0);
+
+        /**
          * The x offset of where to draw from the top left.
          *
          * @name Phaser.Tilemaps.LayerData#x

--- a/src/tilemaps/mapdata/LayerData.js
+++ b/src/tilemaps/mapdata/LayerData.js
@@ -39,7 +39,9 @@ var LayerData = new Class({
         this.name = GetFastValue(config, 'name', 'layer');
 
         /**
-         * The id of the layer, as specified in the map data, NOT the index.
+         * The id of the layer, as specified in the map data.
+         * 
+         * Note: This is not the index of the layer in the map data, but its actual ID in Tiled.
          * 
          * @name Phaser.Tilemaps.LayerData#id
          * @type {number}

--- a/src/tilemaps/mapdata/ObjectLayer.js
+++ b/src/tilemaps/mapdata/ObjectLayer.js
@@ -41,6 +41,15 @@ var ObjectLayer = new Class({
         this.name = GetFastValue(config, 'name', 'object layer');
 
         /**
+         * The id of the object layer, as specified in the map data.
+         * 
+         * @name Phaser.Tilemaps.ObjectLayer#id
+         * @type {number}
+         * @since 3.60.1
+         */
+        this.id = GetFastValue(config, 'id', 0);
+
+        /**
          * The opacity of the layer, between 0 and 1.
          *
          * @name Phaser.Tilemaps.ObjectLayer#opacity

--- a/src/tilemaps/parsers/tiled/ParseTileLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseTileLayers.js
@@ -122,6 +122,7 @@ var ParseTileLayers = function (json, insertNull)
 
             layerData = new LayerData({
                 name: (curGroupState.name + curl.name),
+                id: curl.id,
                 x: (curGroupState.x + GetFastValue(curl, 'offsetx', 0) + layerOffsetX * json.tilewidth),
                 y: (curGroupState.y + GetFastValue(curl, 'offsety', 0) + layerOffsetY * json.tileheight),
                 width: curl.width,
@@ -202,6 +203,7 @@ var ParseTileLayers = function (json, insertNull)
         {
             layerData = new LayerData({
                 name: (curGroupState.name + curl.name),
+                id: curl.id,
                 x: (curGroupState.x + GetFastValue(curl, 'offsetx', 0) + curl.x),
                 y: (curGroupState.y + GetFastValue(curl, 'offsety', 0) + curl.y),
                 width: curl.width,


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR

* Adds a new feature

Describe the changes below:

Before this change, it was not possible to access a Tiled layer (either tilemap layer or object layer) ID directly from the LayerData or ObjectLayer.

This PR adds a new field called `id` to both LayerData and ObjectLayer, as well as adds one additional property in the layer data config, `id`, to retrieve the id property from the already parsed map data.

This would allow users to be able to access the unique layer id of Tiled layers and use it for disambiguation purposes, in the event that a map is given with non-unique layer names.

Related issue: #6541
