### PR TITLE
Add backgroundAlpha property in Circle effect  controller

### DIFF
--- a/src/fx/Circle.js
+++ b/src/fx/Circle.js
@@ -175,8 +175,28 @@ var Circle = new Class({
             color[2] = (value & 0xFF) / 255;
         }
 
-    }
+    },
 
+    /**
+     * The alpha of the background, behind the texture, given as a number value.
+     *
+     * @name Phaser.FX.Circle#backgroundAlpha
+     * @type {number}
+     * @since 3.60.0
+     */
+    backgroundAlpha: {
+
+        get: function ()
+        {
+            return this.glcolor2[3];
+        },
+
+        set: function (value)
+        {
+            this.glcolor2[3] = value;
+        }
+
+    }
 });
 
 module.exports = Circle;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Add `backgroundAlpha` property in Circle effect  controller, so that background could be transparent (set `backgroundAlpha` to `0`)
