### PR TITLE
[Fix] Added missing parameter to some function calls in Phaser.Structs.ProcessQueue#add

### DIFF
--- a/src/gameobjects/components/Texture.js
+++ b/src/gameobjects/components/Texture.js
@@ -56,14 +56,16 @@ var Texture = {
      *
      * @param {(string|Phaser.Textures.Texture)} key - The key of the texture to be used, as stored in the Texture Manager, or a Texture instance.
      * @param {(string|number)} [frame] - The name or index of the frame within the Texture.
+     * @param {boolean} [updateSize=true] - Should this call adjust the size of the Game Object, to be that of the given Frame?
+     * @param {boolean} [updateOrigin=true] - Should this call adjust the origin of the Game Object?
      *
      * @return {this} This Game Object instance.
      */
-    setTexture: function (key, frame)
+    setTexture: function (key, frame, updateSize, updateOrigin)
     {
         this.texture = this.scene.sys.textures.get(key);
 
-        return this.setFrame(frame);
+        return this.setFrame(frame, updateSize, updateOrigin);
     },
 
     /**

--- a/src/structs/ProcessQueue.js
+++ b/src/structs/ProcessQueue.js
@@ -171,7 +171,7 @@ var ProcessQueue = new Class({
     add: function (item)
     {
         //  Don't add if already active or pending, but DO add if active AND in the destroy list
-        if (this.checkQueue && (this.isActive() && !this.isDestroying()) || this.isPending())
+        if (this.checkQueue && (this.isActive(item) && !this.isDestroying(item)) || this.isPending(item))
         {
             return item;
         }


### PR DESCRIPTION
This PR adds the missing parameter (_item_) to the `ProcessQueue.isActive`, `ProcessQueue.isDestroying` and `ProcessQueue.isPending` calls, in ProcessQueue.add method.

