### PR TITLE
[Fix] Added missing parameter to some function calls in Phaser.Structs.ProcessQueue#add

### DIFF
--- a/src/structs/ProcessQueue.js
+++ b/src/structs/ProcessQueue.js
@@ -171,7 +171,7 @@ var ProcessQueue = new Class({
     add: function (item)
     {
         //  Don't add if already active or pending, but DO add if active AND in the destroy list
-        if (this.checkQueue && (this.isActive() && !this.isDestroying()) || this.isPending())
+        if (this.checkQueue && (this.isActive(item) && !this.isDestroying(item)) || this.isPending(item))
         {
             return item;
         }


### PR DESCRIPTION
This PR **fixes a bug**:

It adds the missing parameter (_item_) to the `ProcessQueue.isActive`, `ProcessQueue.isDestroying` and `ProcessQueue.isPending` calls, in ProcessQueue.add method.