### PR TITLE
Fix Geom.Intersects#GetLineToPoints

### DIFF
--- a/src/geom/intersects/GetLineToPoints.js
+++ b/src/geom/intersects/GetLineToPoints.js
@@ -46,9 +46,9 @@ var GetLineToPoints = function (line, points, isRay, out)
     out.set();
     tempIntersect.set();
 
-    var prev = points[0];
+    var prev = points[points.length - 1];
 
-    for (var i = 1; i < points.length; i++)
+    for (var i = 0; i < points.length; i++)
     {
         var current = points[i];
 


### PR DESCRIPTION
This PR

* Fixes a bug

An oversight in the for loop prevented the intersection test between the given `Geom.Line` and the line segment between the first and last point.

Also fixes  #6467 

