### PR TITLE
Uses current faces to do hit-testing

### DIFF
--- a/src/gameobjects/mesh/Mesh.js
+++ b/src/gameobjects/mesh/Mesh.js
@@ -1165,10 +1165,10 @@ var Mesh = new Class({
      */
     setInteractive: function ()
     {
-        var faces = this.faces;
-
         var hitAreaCallback = function (area, x, y)
         {
+            var faces = this.faces;
+
             for (var i = 0; i < faces.length; i++)
             {
                 var face = faces[i];
@@ -1181,7 +1181,7 @@ var Mesh = new Class({
             }
 
             return false;
-        };
+        }.bind(this);
 
         this.scene.sys.input.enable(this, hitAreaCallback);
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Hit-testing of Mesh won't work if faces is changed after invoking `setInteractive()`. Uses current faces to do hit-testing could eliminate this bug. 