### PR TITLE
Update InputConfiguration.js: Clarify alphaTolerance

### DIFF
--- a/src/input/typedefs/InputConfiguration.js
+++ b/src/input/typedefs/InputConfiguration.js
@@ -9,5 +9,5 @@
  * @property {boolean} [useHandCursor=false] - If `true` the Interactive Object will set the `pointer` hand cursor when a pointer is over it. This is a short-cut for setting `cursor: 'pointer'`.
  * @property {string} [cursor] - The CSS string to be used when the cursor is over this Interactive Object.
  * @property {boolean} [pixelPerfect=false] - If `true` the a pixel perfect function will be set for the hit area callback. Only works with image texture based Game Objects, not Render Textures.
- * @property {number} [alphaTolerance=1] - If `pixelPerfect` is set, this is the alpha tolerance threshold value used in the callback.
+ * @property {number} [alphaTolerance=1] - If `pixelPerfect` is set, this is the alpha tolerance threshold value used in the callback. A value of 255 will match only fully opaque pixels.
  */


### PR DESCRIPTION
This PR
* Updates the Documentation

Describe the changes below:
Adds documentation to make it clear that the max alphaTolerance is 255, rather than 1 (as in setAlpha functions).
