### PR TITLE
EmitterOpOnEmitCallback update

### DIFF
--- a/src/gameobjects/particles/typedefs/EmitterOpOnEmitCallback.js
+++ b/src/gameobjects/particles/typedefs/EmitterOpOnEmitCallback.js
@@ -4,9 +4,9 @@
  * @callback Phaser.Types.GameObjects.Particles.EmitterOpOnEmitCallback
  * @since 3.0.0
  *
- * @param {Phaser.GameObjects.Particles.Particle} particle - The particle.
- * @param {string} key - The name of the property.
- * @param {number} value - The current value of the property.
+ * @param {Phaser.GameObjects.Particles.Particle} [particle] - The particle.
+ * @param {string} [key] - The name of the property.
+ * @param {number} [value] - The current value of the property.
  *
  * @return {number} The new value of the property.
  */


### PR DESCRIPTION
Changed the parameters to be optional since not all the onEmit calls actually pass parameters to the function, so there should be a warning about that.

