### PR TITLE
Type clarification for emit zone data

### DIFF
--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -636,7 +636,7 @@ var ParticleEmitter = new Class({
          * In 3.60 they can now have an array of Emission Zones.
          *
          * @name Phaser.GameObjects.Particles.ParticleEmitter#emitZones
-         * @type {Phaser.GameObjects.Particles.Zones.EdgeZone[]|Phaser.GameObjects.Particles.Zones.RandomZone[]}
+         * @type {Phaser.Types.GameObjects.Particles.EmitZoneObject[]}
          * @since 3.60.0
          * @see Phaser.GameObjects.Particles.ParticleEmitter#setEmitZone
          */
@@ -1764,7 +1764,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#addEmitZone
      * @since 3.60.0
      *
-     * @param {Phaser.Types.GameObjects.Particles.EmitZoneObject|Phaser.Types.GameObjects.Particles.EmitZoneObject[]} zone - An Emission Zone configuration object, a RandomZone or EdgeZone instance, or an array of them.
+     * @param {Phaser.Types.GameObjects.Particles.EmitZoneData|Phaser.Types.GameObjects.Particles.EmitZoneData[]} zone - An Emission Zone configuration object, a RandomZone or EdgeZone instance, or an array of them.
      *
      * @return {Phaser.GameObjects.Particles.Zones.EdgeZone[]|Phaser.GameObjects.Particles.Zones.RandomZone[]} An array of the Emission Zones that were added to this Emitter.
      */

--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -1766,7 +1766,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.EmitZoneData|Phaser.Types.GameObjects.Particles.EmitZoneData[]} zone - An Emission Zone configuration object, a RandomZone or EdgeZone instance, or an array of them.
      *
-     * @return {Phaser.GameObjects.Particles.Zones.EdgeZone[]|Phaser.GameObjects.Particles.Zones.RandomZone[]} An array of the Emission Zones that were added to this Emitter.
+     * @return {Phaser.Types.GameObjects.Particles.EmitZoneObject[]} An array of the Emission Zones that were added to this Emitter.
      */
     addEmitZone: function (config)
     {

--- a/src/gameobjects/particles/typedefs/EmitZoneData.js
+++ b/src/gameobjects/particles/typedefs/EmitZoneData.js
@@ -1,0 +1,4 @@
+/**
+ * @typedef {Phaser.Types.GameObjects.Particles.ParticleEmitterEdgeZoneConfig|Phaser.Types.GameObjects.Particles.ParticleEmitterRandomZoneConfig|Phaser.GameObjects.Particles.Zones.EdgeZone|Phaser.GameObjects.Particles.Zones.RandomZone} Phaser.Types.GameObjects.Particles.EmitZoneData
+ * @since 3.60.0
+ */

--- a/src/gameobjects/particles/typedefs/EmitZoneObject.js
+++ b/src/gameobjects/particles/typedefs/EmitZoneObject.js
@@ -1,4 +1,4 @@
 /**
- * @typedef {Phaser.Types.GameObjects.Particles.ParticleEmitterEdgeZoneConfig|Phaser.Types.GameObjects.Particles.ParticleEmitterRandomZoneConfig|Phaser.GameObjects.Particles.Zones.EdgeZone|Phaser.GameObjects.Particles.Zones.RandomZone} Phaser.Types.GameObjects.Particles.EmitZoneObject
+ * @typedef {Phaser.GameObjects.Particles.Zones.EdgeZone|Phaser.GameObjects.Particles.Zones.RandomZone} Phaser.Types.GameObjects.Particles.EmitZoneObject
  * @since 3.60.0
  */

--- a/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
+++ b/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
@@ -52,7 +52,7 @@
  * @property {string} [colorEase] - The string-based name of the Easing function to use if you have enabled Particle color interpolation via the `color` property, otherwise has no effect.
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType} [x] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#particleX}.
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType} [y] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#particleY}.
- * @property {Phaser.Types.GameObjects.Particles.EmitZoneObject|Phaser.Types.GameObjects.Particles.EmitZoneObject[]} [emitZone] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setEmitZone}.
+ * @property {Phaser.Types.GameObjects.Particles.EmitZoneData|Phaser.Types.GameObjects.Particles.EmitZoneData[]} [emitZone] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setEmitZone}.
  * @property {Phaser.Types.GameObjects.Particles.DeathZoneObject|Phaser.Types.GameObjects.Particles.DeathZoneObject[]} [deathZone] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setDeathZone}.
  * @property {Phaser.Types.GameObjects.Particles.ParticleEmitterBounds|Phaser.Types.GameObjects.Particles.ParticleEmitterBoundsAlt} [bounds] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setBounds}.
  * @property {object} [followOffset] - Assigns to {@link Phaser.GameObjects.Particles.ParticleEmitter#followOffset}.


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:

* Updated the definition of EmitZoneObject to exclusively represent EdgeZone or RandomZone objects, excluding their configurations. Previously, the emitZones property was either an array of RandomZones or an array of EdgeZones, but not an array that could hold either. With this change, emitZones is now represented as an array of EmitZoneObjects.
* EmitZoneData takes over the role previously held by EmitZoneObject.
