### PR TITLE
Add setDisplaySize method in BitmapText

### DIFF
--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -860,7 +860,7 @@ var BitmapText = new Class({
      *
      * Calling this will adjust the scale.
      *
-     * @method Phaser.GameObjects.Components.Size#setDisplaySize
+     * @method Phaser.GameObjects.BitmapText#setDisplaySize
      * @since 3.61.0
      *
      * @param {number} width - The width of this BitmapText Game Object.

--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -856,6 +856,34 @@ var BitmapText = new Class({
     },
 
     /**
+     * Sets the display size of this BitmapText Game Object.
+     *
+     * Calling this will adjust the scale.
+     *
+     * @method Phaser.GameObjects.Components.Size#setDisplaySize
+     * @since 3.61.0
+     *
+     * @param {number} width - The width of this BitmapText Game Object.
+     * @param {number} height - The height of this BitmapText Game Object.
+     *
+     * @return {this} This Game Object instance.
+     */
+    setDisplaySize: function (displayWidth, displayHeight)
+    {
+        this.setScale(1, 1);
+
+        this.getTextBounds(false);
+
+        var scaleX = displayWidth / this.width;
+
+        var scaleY = displayHeight / this.height;
+
+        this.setScale(scaleX, scaleY);
+
+        return this;
+    },
+
+    /**
      * Controls the alignment of each line of text in this BitmapText object.
      *
      * Only has any effect when this BitmapText contains multiple lines of text, split with carriage-returns.
@@ -1072,6 +1100,17 @@ var BitmapText = new Class({
      */
     displayWidth: {
 
+        set: function(value)
+        {
+            this.setScaleX(1);
+
+            this.getTextBounds(false);
+
+            var scale = value / this.width;
+
+            this.setScaleX(scale);
+        },
+
         get: function ()
         {
             return this.width;
@@ -1092,6 +1131,17 @@ var BitmapText = new Class({
      * @since 3.60.0
      */
     displayHeight: {
+
+        set: function(value)
+        {
+            this.setScaleY(1);
+
+            this.getTextBounds(false);
+
+            var scale = value / this.height;
+
+            this.setScaleY(scale);
+        },
 
         get: function ()
         {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Since BitmapText does not have original size, I set scaleX, scaleY to `1` to get original size, 
then calculate new scaleX, scaleY by displayWidth, displayHeight.
