### PR TITLE
Updated the description of DeathZoneObj

### DIFF
--- a/src/gameobjects/particles/typedefs/DeathZoneObject.js
+++ b/src/gameobjects/particles/typedefs/DeathZoneObject.js
@@ -1,4 +1,4 @@
 /**
- * @typedef {Phaser.GameObjects.Particles.Zones.DeathZone|Phaser.Types.GameObjects.Particles.ParticleEmitterDeathZoneConfig|Phaser.Geom.Circle|Phaser.Geom.Ellipse|Phaser.Geom.Polygon|Phaser.Geom.Triangle} Phaser.Types.GameObjects.Particles.DeathZoneObject
+ * @typedef {Phaser.GameObjects.Particles.Zones.DeathZone|Phaser.Types.GameObjects.Particles.ParticleEmitterDeathZoneConfig|Phaser.Types.GameObjects.Particles.DeathZoneSource} Phaser.Types.GameObjects.Particles.DeathZoneObject
  * @since 3.60.0
  */


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:

Switched the references of Circle, Ellipse, Polygon, and Triangle for only one reference to the DeathZoneSource
