### PR TITLE
[Layer] Update remove, removeAll, add methods

### DIFF
--- a/src/gameobjects/layer/Layer.js
+++ b/src/gameobjects/layer/Layer.js
@@ -605,6 +605,104 @@ var Layer = new Class({
     },
 
     /**
+     * Adds the given Game Object, or array of Game Objects, to this Layer.
+     *
+     * Each Game Object must be unique within the Layer.
+     *
+     * @method Phaser.GameObjects.Layer#add
+     * @since 3.4.0
+     *
+     * @generic {Phaser.GameObjects.GameObject} T
+     * @genericUse {(T|T[])} - [child]
+     *
+     * @param {Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[]} child - The Game Object, or array of Game Objects, to add to the Layer.
+     *
+     * @return {this} This Layer instance.
+     */
+    add: function(child)
+    {
+        List.prototype.add.call(this, child);
+
+        return this;
+    },
+
+    /**
+     * Removes the given Game Object, or array of Game Objects, from this Layer.
+     *
+     * The Game Objects must already be children of this Layer.
+     *
+     * You can also optionally call `destroy` on each Game Object that is removed from the Layer.
+     *
+     * @method Phaser.GameObjects.Layer#remove
+     * @since 3.61.0
+     *
+     * @generic {Phaser.GameObjects.GameObject} T
+     * @genericUse {(T|T[])} - [child]
+     *
+     * @param {Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[]} child - The Game Object, or array of Game Objects, to be removed from the Layer.
+     * @param {boolean} [destroyChild=false] - Optionally call `destroy` on each child successfully removed from this Layer.
+     *
+     * @return {this} This Layer instance.
+     */
+    remove: function (child, destroyChild)
+    {
+        var removed = List.prototype.remove.call(this, child);
+
+        if (destroyChild && removed)
+        {
+            if (!Array.isArray(removed))
+            {
+                removed = [ removed ];
+            }
+
+            for (var i = 0; i < removed.length; i++)
+            {
+                removed[i].destroy();
+            }
+        }
+
+        return this;
+    },
+
+    /**
+     * Removes all Game Objects from this Layer.
+     *
+     * You can also optionally call `destroy` on each Game Object that is removed from the Layer.
+     *
+     * @method Phaser.GameObjects.Layer#removeAll
+     * @since 3.4.0
+     *
+     * @param {boolean} [destroyChild=false] - Optionally call `destroy` on each Game Object successfully removed from this Layer.
+     *
+     * @return {this} This Layer instance.
+     */
+    removeAll: function (destroyChild)
+    {
+        var list = this.list;
+
+        if (destroyChild)
+        {
+            for (var i = 0; i < list.length; i++)
+            {
+                if (list[i] && list[i].scene)
+                {
+                    list[i].off(GameObjectEvents.DESTROY, this.remove, this);
+
+                    list[i].destroy();
+                }
+            }
+
+            this.list = [];
+        }
+        else
+        {
+            ArrayUtils.RemoveBetween(list, 0, list.length, this.removeChildCallback, this);
+        }
+
+        return this;
+    },
+
+    /**
      * This callback is invoked when this Game Object is added to a Scene.
      *
      * Can be overriden by custom Game Objects, but be aware of some Game Objects that
@@ -730,6 +828,8 @@ var Layer = new Class({
      */
     addChildCallback: function (gameObject)
     {
+        gameObject.once(GameObjectEvents.DESTROY, this.remove, this);
+
         if (gameObject.displayList && gameObject.displayList !== this)
         {
             gameObject.removeFromDisplayList();
@@ -760,6 +860,8 @@ var Layer = new Class({
      */
     removeChildCallback: function (gameObject)
     {
+        gameObject.off(GameObjectEvents.DESTROY, this.remove, this);
+
         this.queueDepthSort();
 
         gameObject.displayList = null;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

- Destroy child game object will remove it from Layer
- Method `add`, `remove`, `removeAll` now will `return this`, for method chaining.
- Add `destroyChild` parameter to method `remove`, `removeAll`, logic is the same as `remove`, `removeAll` in Container game object.
