### PR TITLE
Add read-only originX, originY properties

### DIFF
--- a/src/gameobjects/plane/Plane.js
+++ b/src/gameobjects/plane/Plane.js
@@ -136,6 +136,42 @@ var Plane = new Class({
         this.setViewHeight();
     },
 
+    /**     
+     * Do not change this value. It has no effect other than to break things.
+     *
+     * @name Phaser.GameObjects.Plane#originX
+     * @type {number}
+     * @readonly
+     * @override
+     * @since 3.61.0
+     */
+    originX: {
+
+        get: function ()
+        {
+            return 0.5;
+        }
+
+    },
+
+    /**     
+     * Do not change this value. It has no effect other than to break things.
+     *
+     * @name Phaser.GameObjects.Plane#originY
+     * @type {number}
+     * @readonly
+     * @override
+     * @since 3.61.0
+     */
+    originY: {
+
+        get: function ()
+        {
+            return 0.5;
+        }
+
+    },
+
     /**
      * Modifies the layout of this Plane by adjusting the grid dimensions to the
      * given width and height. The values are given in cells, not pixels.


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Plane game object can have read-only originX, originY properties.
