### PR TITLE
Update matter.d.ts

### DIFF
--- a/types/matter.d.ts
+++ b/types/matter.d.ts
@@ -1431,6 +1431,11 @@ declare namespace MatterJS {
         angle: number;
 
         /**
+        * A `Number` specifying the delta time, in ms, since the last game step
+        */
+        deltaTime: number;
+        
+        /**
          * An array of `Vector` objects that specify the convex hull of the rigid body.
          * These should be provided about the origin `(0, 0)`. E.g.
          *


### PR DESCRIPTION
This PR adds a missing property to the MatterJS BodyType type.


Describe the changes below:
* I added BodyType.deltaTime: number to match property change as described here: https://github.com/photonstorm/phaser/discussions/6452
