### PR TITLE
Added to the description that EmitterColorOp is an extension

### DIFF
--- a/src/gameobjects/particles/EmitterColorOp.js
+++ b/src/gameobjects/particles/EmitterColorOp.js
@@ -19,6 +19,7 @@ var IntegerToRGB = require('../../display/color/IntegerToRGB');
  * See the `ParticleEmitter` class for more details on emitter op configuration.
  *
  * @class EmitterColorOp
+ * @extends Phaser.GameObjects.Particles.EmitterOp
  * @memberof Phaser.GameObjects.Particles
  * @constructor
  * @since 3.60.0


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:

* Added to the description that EmitterColorOp is an extension of the EmitterOp class.

