### PR TITLE
Add getter of tint property

### DIFF
--- a/src/gameobjects/components/Tint.js
+++ b/src/gameobjects/components/Tint.js
@@ -182,7 +182,7 @@ var Tint = {
 
     /**
      * The tint value being applied to the whole of the Game Object.
-     * This property is a setter-only. Use the properties `tintTopLeft` etc to read the current tint value.
+     * Return `tintTopLeft` when read this tint property.
      *
      * @name Phaser.GameObjects.Components.Tint#tint
      * @type {number}
@@ -190,6 +190,11 @@ var Tint = {
      * @since 3.0.0
      */
     tint: {
+
+        get: function()
+        {
+            return this.tintTopLeft;
+        },
 
         set: function (value)
         {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Since setter of `tint` will set `tintTopLeft`, `tintTopRight`, `tintBottomLeft`, `tintBottomRight` together, i.e. value of these 4 properties are equal. So that it can return `tintTopLeft` value as the getter of `tint` property, imo.
