### PR TITLE
Fixed jsdoc for GetRandom

### DIFF
--- a/src/utils/array/GetRandom.js
+++ b/src/utils/array/GetRandom.js
@@ -10,11 +10,15 @@
  * @function Phaser.Utils.Array.GetRandom
  * @since 3.0.0
  *
- * @param {array} array - The array to select the random entry from.
+ * @generic T
+ * @genericUse {T[]} - [array]
+ * @genericUse {T} - [$return]
+ *
+ * @param {T[]} array - The array to select the random entry from.
  * @param {number} [startIndex=0] - An optional start index.
  * @param {number} [length=array.length] - An optional length, the total number of elements (from the startIndex) to choose from.
  *
- * @return {*} A random element from the array, or `null` if no element could be found in the range given.
+ * @return {T} A random element from the array, or `null` if no element could be found in the range given.
  */
 var GetRandom = function (array, startIndex, length)
 {


### PR DESCRIPTION
Added generic for return in `Utils.Array.GetRandom` function