### PR TITLE
Update GetPoints.js

### DIFF
--- a/src/geom/line/GetPoints.js
+++ b/src/geom/line/GetPoints.js
@@ -43,12 +43,16 @@ var GetPoints = function (line, quantity, stepRate, out)
     var x2 = line.x2;
     var y2 = line.y2;
 
+    var dx = x2 - x1;
+    var dy = y2 - y1;
+
+    var distance = Math.sqrt(dx * dx + dy * dy);
+    var stepSize = distance / (quantity - 1);
+
     for (var i = 0; i < quantity; i++)
     {
-        var position = i / quantity;
-
-        var x = x1 + (x2 - x1) * position;
-        var y = y1 + (y2 - y1) * position;
+        var x = x1 + (dx / distance) * (stepSize * i);
+        var y = y1 + (dy / distance) * (stepSize * i);
 
         out.push(new Point(x, y));
     }


### PR DESCRIPTION
This PR

* Adds a new feature
* Updates existing code

Fixes #6439 partially based on @AlitaStudio proposed solution.
This PR only applies to `Geom.Line.GetPoints` calculation metioned in the issue. `Actions.Spread` calculation is not affected by this PR.
`Geom.Line.GetPoints` and `Phaser.Actions.PlaceOnLine` are affected by this PR.
Merging this PR will potentially cause issues for users later on (after updating Phaser version) as this will change the x/y coords of GameObjects that are placed on a `Phaser.Geom.Line` via `Phaser.Actions.PlaceOnLine`.

Example of how `Phaser.GameObjects.GameObject` were placed on a line before this change:
![place_on_line_before](https://github.com/photonstorm/phaser/assets/32781349/22aa5c6b-cfe7-4952-911a-a3c71b5f1e2d)

Example of how `Phaser.GameObjects.GameObject` will be placed on a line after this change:
![place_on_line](https://github.com/photonstorm/phaser/assets/32781349/dda1aa26-b611-499c-92dc-1ac879c21700)
