### PR TITLE
Correcting animation frame-step when all frames have duration value provided

### DIFF
--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -114,9 +114,9 @@ var Animation = new Class({
          * @type {boolean}
          * @since 3.0.0
          */
-        this.allFramesHaveDuration = !this.frames.some(function (frame)
+        this.allFramesHaveDuration = this.frames.every(function (frame)
         {
-            return frame.duration === undefined;
+            return frame.duration !== undefined;
         });
 
         /**

--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -116,7 +116,7 @@ var Animation = new Class({
          */
         this.allFramesHaveDuration = this.frames.every(function (frame)
         {
-            return frame.duration !== undefined;
+            return frame.duration !== 0;
         });
 
         /**

--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -106,6 +106,20 @@ var Animation = new Class({
         this.duration = GetValue(config, 'duration', null);
 
         /**
+         * Whether or not the `duration` property has been set for all frames of the animation.
+         * If the duration is available on all frames, the next tick will be calculated using only
+         * frame duration data.
+         * 
+         * @name Phaser.Animations.Animation#allFramesHaveDuration
+         * @type {boolean}
+         * @since 3.0.0
+         */
+        this.allFramesHaveDuration = !this.frames.some(function (frame)
+        {
+            return frame.duration === undefined;
+        });
+
+        /**
          * How many ms per frame, not including frame specific modifiers.
          *
          * @name Phaser.Animations.Animation#msPerFrame
@@ -362,7 +376,7 @@ var Animation = new Class({
         //  When is the first update due?
         state.accumulator = 0;
 
-        state.nextTick = state.msPerFrame + state.currentFrame.duration;
+        state.nextTick = (state.currentAnim.allFramesHaveDuration ? 0 : state.msPerFrame) + state.currentFrame.duration;
     },
 
     /**
@@ -515,7 +529,7 @@ var Animation = new Class({
     {
         state.accumulator -= state.nextTick;
 
-        state.nextTick = state.msPerFrame + state.currentFrame.duration;
+        state.nextTick = (state.currentAnim.allFramesHaveDuration ? 0 : state.msPerFrame) + state.currentFrame.duration;
     },
 
     /**


### PR DESCRIPTION
This PR:

* Fixes a bug

Describe the changes below:

I noticed the total animation duration was not correct when defining an animation with frames that each have a duration value provided.

For example, for a 5-frame animation with each frame's duration set to 100ms I was seeing a total animation duration of 1000ms instead of 500ms. I looked into the source and saw that the next tick for the frame-step is always adding the calculated `msPerFrame` to the `currentFrame.duration` (100ms + 100ms in this case; resulting in 200ms for each frame, and 1000ms for the entire animation).

I made an update to the logic that takes into consideration if all the frames for the animation have duration values provided. In this case, the calculated `msPerFrame` is not needed when determining the `nextTick` value.

This change results in the example 5-frame animation correctly taking 500ms overall, with 100ms for each frame.

I have tested and verified the change in my own test project, but please take a look and let me know if there is anything I am not considering.

Phaser is amazing, thanks!