### PR TITLE
Remove DESTROY event before destroy child game object

### DIFF
--- a/src/gameobjects/layer/Layer.js
+++ b/src/gameobjects/layer/Layer.js
@@ -1053,6 +1053,8 @@ var Layer = new Class({
 
         while (list.length)
         {
+            list[0].off(GameObjectEvents.DESTROY, this.remove, this);
+
             list[0].destroy(fromScene);
         }
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Remove DESTROY event before destroy child game object. Like [`removeAll()`](https://github.com/photonstorm/phaser/blob/master/src/gameobjects/layer/Layer.js#L690) does.

Fix #6675 
