### PR TITLE
Fix `InputManager.onTouchMove` to work on scrolled-down pages

### DIFF
--- a/src/input/InputManager.js
+++ b/src/input/InputManager.js
@@ -614,7 +614,7 @@ var InputManager = new Class({
 
                 if (pointer.active && pointer.identifier === changedTouch.identifier)
                 {
-                    var element = document.elementFromPoint(changedTouch.pageX, changedTouch.pageY);
+                    var element = document.elementFromPoint(changedTouch.clientX, changedTouch.clientY);
                     var overCanvas = element === this.canvas;
 
                     if (!this.isOver && overCanvas)


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

Fix `InputManager.onTouchMove` to work on scrolled-down pages

`document.elementFromPoint` expects plain viewport coordinates [1], while we used `page[XY]`, which are viewport coordinates with added scroll offsets [2].

So on pages where no scrolling had yet occurred,
`InputManager.onTouchMove` worked as expected. But as soon as one scrolled down/right on the page, the element detection was off by the scroll offset.

We switch from `page[XY]` to `client[XY]` which are plain viewport coordinates [3] and thereby make element detection work also on pages that have been scrolled around.

[1] https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint
[2] https://w3c.github.io/touch-events/#dom-touch-pagex
[3] https://w3c.github.io/touch-events/#dom-touch-clientx
