### PR TITLE
Fix removing destroyed Container children

### DIFF
--- a/src/gameobjects/container/Container.js
+++ b/src/gameobjects/container/Container.js
@@ -438,7 +438,7 @@ var Container = new Class({
      */
     addHandler: function (gameObject)
     {
-        gameObject.once(Events.DESTROY, this.remove, this);
+        gameObject.once(Events.DESTROY, this.onChildDestroyed, this);
 
         if (this.exclusive)
         {
@@ -976,7 +976,7 @@ var Container = new Class({
             {
                 if (list[i] && list[i].scene)
                 {
-                    list[i].off(Events.DESTROY, this.remove, this);
+                    list[i].off(Events.DESTROY, this.onChildDestroyed, this);
 
                     list[i].destroy();
                 }
@@ -1452,6 +1452,25 @@ var Container = new Class({
         this.tempTransformMatrix.destroy();
 
         this.list = [];
+    },
+
+    /**
+     * Internal handler, called when a child is destroyed.
+     *
+     * @method Phaser.GameObjects.Container#onChildDestroyed
+     * @protected
+     * @since 3.70.1
+     */
+    onChildDestroyed: function (gameObject)
+    {
+        ArrayUtils.Remove(this.list, gameObject);
+
+        if (this.exclusive)
+        {
+            gameObject.parentContainer = null;
+
+            gameObject.removedFromScene();
+        }
     }
 
 });


### PR DESCRIPTION
This PR

* Fixes a bug

There were two problems with destroying Container children. I fixed them by hooking the child's DESTROY event to a new `onChildDestroyed()` method instead of `remove()`.

1.  If you destroyed a game object in an exclusive Container, the game object would (momentarily) move onto the scene display list and emit an ADDED_TO_SCENE event.

2.  If you added a Sprite to a nonexclusive Container and stopped the scene, you would get a TypeError (evaluating 'this.anims.destroy'). This happened because the `fromChild` argument in the DESTROY event was misinterpreted as `destroyChild` in the Container's `remove()`, and the Container was calling the Sprite's `destroy()` again.



