### PR TITLE
Check for undefined to avoid a crash in the examples at phaser3-custo…

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -577,7 +577,7 @@ var SceneManager = new Class({
                 sys.step(time, delta);
             }
 
-            if (sys.scenePlugin._target)
+            if (sys.scenePlugin && sys.scenePlugin._target)
             {
                 sys.scenePlugin.step(time, delta);
             }


### PR DESCRIPTION
…m-build.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The test/index.html and other examples at
https://github.com/photonstorm/phaser3-custom-build
crash because it tries to access `sys.scenePlugin._target` when `sys.scenePlugin` is `undefined`.
When I made this change locally it got them working again.