### PR TITLE
Add EXPAND scale mode

### DIFF
--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -431,7 +431,7 @@ var ScaleManager = new Class({
 
         this.fullscreen = game.device.fullscreen;
 
-        if (this.scaleMode !== CONST.SCALE_MODE.RESIZE)
+        if ((this.scaleMode !== CONST.SCALE_MODE.RESIZE) && (this.scaleMode !== CONST.SCALE_MODE.EXPAND))
         {
             this.displaySize.setAspectMode(this.scaleMode);
         }
@@ -1046,6 +1046,53 @@ var ScaleManager = new Class({
 
             this.canvas.width = styleWidth;
             this.canvas.height = styleHeight;
+        }
+        else if (this.scaleMode === CONST.SCALE_MODE.EXPAND)
+        {            
+            //  Resize to match parent, like RESIZE mode
+
+            //  This will constrain using min/max
+            this.displaySize.setSize(this.parentSize.width, this.parentSize.height);
+            
+            styleWidth = this.displaySize.width;
+            styleHeight = this.displaySize.height;
+
+            if (autoRound)
+            {
+                styleWidth = Math.floor(styleWidth);
+                styleHeight = Math.floor(styleHeight);
+            }
+
+            style.width = styleWidth + 'px';
+            style.height = styleHeight + 'px';
+
+
+            // Expand canvas size to fit game size's width or height
+
+            var scaleX = this.parentSize.width / this.gameSize.width;
+
+            var scaleY = this.parentSize.height / this.gameSize.height;
+
+            if (scaleX < scaleY) 
+            {
+                this.baseSize.setSize(this.gameSize.width, this.parentSize.height / scaleX);
+            } 
+            else
+            {
+                this.baseSize.setSize(this.displaySize.width / scaleY, this.gameSize.height);
+            }
+
+            styleWidth = this.baseSize.width;
+            styleHeight = this.baseSize.height;
+
+            if (autoRound)
+            {
+                styleWidth = Math.floor(styleWidth);
+                styleHeight = Math.floor(styleHeight);
+            }
+
+            this.canvas.width = styleWidth;
+            this.canvas.height = styleHeight;           
         }
         else
         {

--- a/src/scale/const/SCALE_MODE_CONST.js
+++ b/src/scale/const/SCALE_MODE_CONST.js
@@ -87,6 +87,17 @@ module.exports = {
      * @const
      * @since 3.16.0
      */
-    RESIZE: 5
+    RESIZE: 5,
+
+    /**
+     * The Canvas's visible area is resized to fit all available _parent_ space like RESIZE mode,
+     * and scale canvas size to fit inside the visible area like FIT mode.
+     *
+     * @name Phaser.Scale.ScaleModes.EXPAND
+     * @type {number}
+     * @const
+     * @since 3.70.1
+     */
+    EXPAND : 6
 
 };


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Add new scale mode EXPAND, referenced from godot's [Stretch Aspect = Expand:](https://docs.godotengine.org/en/4.1/tutorials/rendering/multiple_resolutions.html#stretch-aspect).

```
Keep aspect ratio when stretching the screen, but keep neither the base width nor height. Depending on the screen aspect ratio, the viewport will either be larger in the horizontal direction (if the screen is wider than the base size) or in the vertical direction (if the screen is taller than the original size)
```

![img](https://docs.godotengine.org/en/4.1/_images/stretch_viewport_expand.gif)

The implement concept is 

- Resize canvas's visible area (style.width, style.height of canvas) to fit all available *parent* space like RESIZE mode (line 1055-1067)
- Resize canvas's size (canvas.width, canvas.height) to fit inside the visible area like FIT mode. (line 1072-1095)

Test code

```js
class Demo extends Phaser.Scene {
    constructor() {
        super({
            key: 'examples'
        })
    }

    preload() {
        // A 800x600 image which equal to whole game size
        this.load.image('classroom', 'https://raw.githubusercontent.com/rexrainbow/phaser3-rex-notes/master/assets/images/backgrounds/classroom.png');
    }

    create() {
        this.add.image(0, 0, 'classroom').setOrigin(0)
    }

    update() { }
}

var config = {
    type: Phaser.AUTO,
    parent: 'phaser-example',
    width: 800,
    height: 600,
    scale: {
        mode: Phaser.Scale.EXPAND,
        autoCenter: Phaser.Scale.CENTER_BOTH,
    },
    backgroundColor: 0x888888,
    scene: Demo
};

var game = new Phaser.Game(config);
```