### PR TITLE
fix nineslice hit areas

### DIFF
--- a/src/gameobjects/nineslice/NineSlice.js
+++ b/src/gameobjects/nineslice/NineSlice.js
@@ -839,7 +839,7 @@ var NineSlice = new Class({
     {
         this.width = width;
         this.height = height;
-
+        this.updateDisplayOrigin();
         var input = this.input;
 
         if (input && !input.customHitArea)


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug #6713. 

Describe the changes below:

Calls the existing code to recalculate the origin for nine slice gameobject. 