### PR TITLE
Flip order of tile visibility check and camera culling

### DIFF
--- a/src/tilemaps/components/IsometricCullTiles.js
+++ b/src/tilemaps/components/IsometricCullTiles.js
@@ -50,17 +50,19 @@ var IsometricCullTiles = function (layer, camera, outputArray, renderOrder)
         {
             for (x = drawLeft; x < drawRight; x++)
             {
+                tile = mapData[y][x];
+
+                if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
+                {
+                    continue;
+                }
+
                 if (skipCull || CheckIsoBounds(x, y, layer, camera))
                 {
-                    tile = mapData[y][x];
-
-                    if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
-                    {
-                        continue;
-                    }
-
-                    outputArray.push(tile);
+                    continue;
                 }
+
+                outputArray.push(tile);
             }
         }
     }
@@ -72,17 +74,19 @@ var IsometricCullTiles = function (layer, camera, outputArray, renderOrder)
         {
             for (x = drawRight; x >= drawLeft; x--)
             {
+                tile = mapData[y][x];
+
+                if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
+                {
+                    continue;
+                }
+
                 if (skipCull || CheckIsoBounds(x, y, layer, camera))
                 {
-                    tile = mapData[y][x];
-
-                    if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
-                    {
-                        continue;
-                    }
-
-                    outputArray.push(tile);
+                    continue;
                 }
+
+                outputArray.push(tile);
             }
         }
     }
@@ -94,17 +98,19 @@ var IsometricCullTiles = function (layer, camera, outputArray, renderOrder)
         {
             for (x = drawLeft; x < drawRight; x++)
             {
+                tile = mapData[y][x];
+
+                if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
+                {
+                    continue;
+                }
+
                 if (skipCull || CheckIsoBounds(x, y, layer, camera))
                 {
-                    tile = mapData[y][x];
-
-                    if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
-                    {
-                        continue;
-                    }
-
-                    outputArray.push(tile);
+                    continue;
                 }
+
+                outputArray.push(tile);
             }
         }
     }
@@ -116,17 +122,19 @@ var IsometricCullTiles = function (layer, camera, outputArray, renderOrder)
         {
             for (x = drawRight; x >= drawLeft; x--)
             {
+                tile = mapData[y][x];
+
+                if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
+                {
+                    continue;
+                }
+
                 if (skipCull || CheckIsoBounds(x, y, layer, camera))
                 {
-                    tile = mapData[y][x];
-
-                    if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
-                    {
-                        continue;
-                    }
-
-                    outputArray.push(tile);
+                    continue;
                 }
+
+                outputArray.push(tile);
             }
         }
     }


### PR DESCRIPTION
This PR
* Fixes a bug with the camera culling of isometric tiles by changing the order of checks to improve rendering speed

Describe the changes below:
In our game with 200x200 tiles, tile culling takes up a significant portion of render time. We tried disabling the visibility of certain tiles as a speedup measure, but realized that the culling will not check the visibility of the tile until *after* it has checked if it's in bounds. Since the bounds check is significantly heavier than the `visible` flag check, reversing the order of the checks in the code so it checks the flags before doing the camera bounds check noticeably decreases render time. On some of our lower specced computers (where the cpu is a potential bottleneck), average cull time changes from ~10ms (without the patch) to ~5ms (with the patch).

Unless there is something I'm missing, this seems like a trivial change that can decrease the time phaser spends in the render loop.