### PR TITLE
docs: clarify overlapOnly param

### DIFF
--- a/src/physics/arcade/Collider.js
+++ b/src/physics/arcade/Collider.js
@@ -10,6 +10,9 @@ var Class = require('../../utils/Class');
  * @classdesc
  * An Arcade Physics Collider will automatically check for collision, or overlaps, between two objects
  * every step. If a collision, or overlap, occurs it will invoke the given callbacks.
+ * 
+ * Note, if setting `overlapOnly` to `true`, and one of the objects is a `TilemapLayer`, every tile in the layer, regardless of tile ID, will be checked for collision. 
+ * Even if the layer has had only a subset of tile IDs enabled for collision, all tiles will still be checked for overlap.
  *
  * @class Collider
  * @memberof Phaser.Physics.Arcade
@@ -17,9 +20,7 @@ var Class = require('../../utils/Class');
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Arcade.World} world - The Arcade physics World that will manage the collisions.
- * @param {boolean} overlapOnly - Whether to check for collisions or overlaps. Note, if checking for overlaps with a 
- * TilemapLayer, every tile in the layer, regardless of tile ID, will be checked for collision. 
- * Even if the layer has had only a subset of tile IDs enabled for collision, all tiles will still be checked for overlap.
+ * @param {boolean} overlapOnly - Whether to check for collisions or overlaps.
  * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} object1 - The first object to check for collision.
  * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} object2 - The second object to check for collision.
  * @param {Phaser.Types.Physics.Arcade.ArcadePhysicsCallback} collideCallback - The callback to invoke when the two objects collide.

--- a/src/physics/arcade/Collider.js
+++ b/src/physics/arcade/Collider.js
@@ -17,7 +17,9 @@ var Class = require('../../utils/Class');
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Arcade.World} world - The Arcade physics World that will manage the collisions.
- * @param {boolean} overlapOnly - Whether to check for collisions or overlap.
+ * @param {boolean} overlapOnly - Whether to check for collisions or overlaps. Note, if checking for overlaps with a 
+ * TilemapLayer, every tile in the layer, regardless of tile ID, will be checked for collision. 
+ * Even if the layer has had only a subset of tile IDs enabled for collision, all tiles will still be checked for overlap.
  * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} object1 - The first object to check for collision.
  * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} object2 - The second object to check for collision.
  * @param {Phaser.Types.Physics.Arcade.ArcadePhysicsCallback} collideCallback - The callback to invoke when the two objects collide.


### PR DESCRIPTION
in Phaser.Physics.Arcade.Collider

Explain that the callback will trigger on any overlap with any part of a tileLayer

Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation


