### PR TITLE
Exclude the renderers by feature flag

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -14,9 +14,17 @@
 
 module.exports = {
 
-    Canvas: require('./canvas'),
     Events: require('./events'),
-    Snapshot: require('./snapshot'),
-    WebGL: require('./webgl')
+    Snapshot: require('./snapshot')
 
 };
+
+if (typeof CANVAS_RENDERER)
+{
+    module.exports.Canvas = require('./canvas');
+}
+
+if (typeof WEBGL_RENDERER)
+{
+    module.exports.WebGL = require('./webgl');
+}


### PR DESCRIPTION
This PR

* Adds a new feature

This includes `Phaser.Renderer.Canvas` or `Phaser.Renderer.WebGL` only if the corresponding feature flags `CANVAS_RENDERER` or `WEBGL_RENDERER` are true.

For Canvas-only builds this saves a lot.

