### PR TITLE
Fixing the Postfix pipeline without introducing a skip frame

### DIFF
--- a/src/renderer/webgl/pipelines/PostFXPipeline.js
+++ b/src/renderer/webgl/pipelines/PostFXPipeline.js
@@ -288,11 +288,14 @@ var PostFXPipeline = new Class({
         if (!this.hasBooted)
         {
             this.bootFX();
+
+            if (this.currentRenderTarget)
+            {
+                this.currentRenderTarget.bind();
+            }
         }
-        else
-        {
-            this.onDraw(this.currentRenderTarget);
-        }
+
+        this.onDraw(this.currentRenderTarget);
 
         this.onPostBatch(gameObject);
 


### PR DESCRIPTION
This PR

* Fixes a bug


Due to #6681, we introduced a skip frame to wait for the PostFX pipeline to be correctly booted. While this fixed the display issue, it introduced a "skip" frame. The pipeline would only be visible one frame after being introduced.

The root issue is a binding issue on `currentRenderTarget`.

Here, we fix the root issue and remove the skip frame.

I did not find this solution myself. The credit goes to @tongliang999 here: https://github.com/rexrainbow/phaser3-rex-notes/issues/395#issuecomment-1923274315

I tested the new fix in both Chrome and Firefox and can confirm it works.