### PR TITLE
File creation checks if URL is a string before seeing if its Base64

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -240,7 +240,7 @@ var File = new Class({
          * @type {boolean}
          * @since 3.80.0
          */
-        this.base64 = (url.indexOf('data:') === 0);
+        this.base64 = (typeof url === 'string') && (url.indexOf('data:') === 0);
     },
 
     /**


### PR DESCRIPTION
This PR

* Fixes a bug

Fixes #6733 where `File.url` can be a object with the JSON data or a string but is assumed to only be a string when checking if a Base64 URI was used