### PR TITLE
Support EXPAND scale mode in scale.getViewport method

### DIFF
--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -1618,7 +1618,7 @@ var ScaleManager = new Class({
         var y = (canvasBounds.y >= 0) ? 0 : -(canvasBounds.y * displayScale.y);
 
         var width;
-        if (parentSize.width >= canvasBounds.width)
+        if ((parentSize.width >= canvasBounds.width) || (this.scaleMode === CONST.SCALE_MODE.EXPAND))
         {
             width = baseSize.width;
         }
@@ -1628,7 +1628,7 @@ var ScaleManager = new Class({
         }
 
         var height;
-        if (parentSize.height >= canvasBounds.height)
+        if ((parentSize.height >= canvasBounds.height) || (this.scaleMode === CONST.SCALE_MODE.EXPAND))
         {
             height = baseSize.height;
         }


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

GetViewport method does not work EXPAND mode before.