### PR TITLE
bug: Add missing type definition in SpriteConfig

### DIFF
--- a/src/gameobjects/sprite/typedefs/SpriteConfig.js
+++ b/src/gameobjects/sprite/typedefs/SpriteConfig.js
@@ -6,4 +6,5 @@
  * @property {(string|Phaser.Textures.Texture)} [key] - The key, or instance of the Texture this Game Object will use to render with, as stored in the Texture Manager.
  * @property {(string|number)} [frame] - An optional frame from the Texture this Game Object is rendering with.
  * @property {(string|Phaser.Animations.Animation|Phaser.Types.Animations.PlayAnimationConfig)} [anims] - The string-based key of the animation to play, or an Animation instance, or a `PlayAnimationConfig` object.
+ * @property {(boolean)} [useSpriteSheet] - If set to `true` it uses a tileset loaded as a sprite sheet (not an image), and sets the Sprite key and frame to match the sprite texture and tile index.
  */


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

This PR adds the missing type definition for the boolean `useSpriteSheet` property in the `SpriteConfig.js` file, that is later used conditionally in a function in the `CreateFromTiles.js` file.

Closes #6752 

