### PR TITLE
Avoid errors in SSR environments due to missing client interfaces

### DIFF
--- a/src/device/Audio.js
+++ b/src/device/Audio.js
@@ -45,7 +45,7 @@ var Audio = {
 
 function init ()
 {
-    if (typeof importScripts === 'function')
+    if (typeof importScripts === 'function' || typeof window === 'undefined')
     {
         return Audio;
     }

--- a/src/device/Browser.js
+++ b/src/device/Browser.js
@@ -52,6 +52,11 @@ var Browser = {
 
 function init ()
 {
+    if (typeof navigator === 'undefined')
+    {
+        return Browser;
+    }
+
     var ua = navigator.userAgent;
 
     if ((/Edg\/\d+/).test(ua))

--- a/src/device/CanvasFeatures.js
+++ b/src/device/CanvasFeatures.js
@@ -100,7 +100,7 @@ function checkInverseAlpha ()
 
 function init ()
 {
-    if (typeof importScripts !== 'function' && document !== undefined)
+    if (typeof importScripts !== 'function' && typeof Image !== 'undefined')
     {
         CanvasFeatures.supportNewBlendModes = checkBlendMode();
         CanvasFeatures.supportInverseAlpha = checkInverseAlpha();

--- a/src/device/Features.js
+++ b/src/device/Features.js
@@ -80,7 +80,7 @@ function checkIsLittleEndian ()
 
 function init ()
 {
-    if (typeof importScripts === 'function')
+    if (typeof importScripts === 'function' || typeof window === 'undefined')
     {
         return Features;
     }

--- a/src/device/Fullscreen.js
+++ b/src/device/Fullscreen.js
@@ -34,7 +34,7 @@ var Fullscreen = {
 */
 function init ()
 {
-    if (typeof importScripts === 'function')
+    if (typeof importScripts === 'function' || typeof window === 'undefined')
     {
         return Fullscreen;
     }

--- a/src/device/Input.js
+++ b/src/device/Input.js
@@ -31,7 +31,7 @@ var Input = {
 
 function init ()
 {
-    if (typeof importScripts === 'function')
+    if (typeof importScripts === 'function' || typeof window === 'undefined')
     {
         return Input;
     }

--- a/src/device/OS.js
+++ b/src/device/OS.js
@@ -61,7 +61,7 @@ var OS = {
 
 function init ()
 {
-    if (typeof importScripts === 'function')
+    if (typeof importScripts === 'function' || typeof window === 'undefined')
     {
         return OS;
     }
@@ -148,17 +148,15 @@ function init ()
         OS.webApp = true;
     }
 
-    if (typeof importScripts !== 'function')
-    {
-        if (window.cordova !== undefined)
-        {
-            OS.cordova = true;
-        }
 
-        if (window.ejecta !== undefined)
-        {
-            OS.ejecta = true;
-        }
+    if (window.cordova !== undefined)
+    {
+        OS.cordova = true;
+    }
+
+    if (window.ejecta !== undefined)
+    {
+        OS.ejecta = true;
     }
 
     if (typeof process !== 'undefined' && process.versions && process.versions.node)

--- a/src/device/Video.js
+++ b/src/device/Video.js
@@ -43,7 +43,7 @@ var Video = {
 
 function init ()
 {
-    if (typeof importScripts === 'function')
+    if (typeof importScripts === 'function' || typeof window === 'undefined')
     {
         return Video;
     }

--- a/src/polyfills/requestVideoFrame.js
+++ b/src/polyfills/requestVideoFrame.js
@@ -1,6 +1,6 @@
 //  From https://github.com/ThaUnknown/rvfc-polyfill
 
-if (HTMLVideoElement && !('requestVideoFrameCallback' in HTMLVideoElement.prototype) && 'getVideoPlaybackQuality' in HTMLVideoElement.prototype)
+if (typeof HTMLVideoElement !== 'undefined' && !('requestVideoFrameCallback' in HTMLVideoElement.prototype) && 'getVideoPlaybackQuality' in HTMLVideoElement.prototype)
 {
     HTMLVideoElement.prototype._rvfcpolyfillmap = {}
     HTMLVideoElement.prototype.requestVideoFrameCallback = function (callback) {

--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -30,7 +30,7 @@ var WebGLUniformLocationWrapper = require('./wrappers/WebGLUniformLocationWrappe
 
 var DEBUG = false;
 
-if (typeof WEBGL_DEBUG)
+if (typeof WEBGL_DEBUG && typeof window !== 'undefined')
 {
     var SPECTOR = require('phaser3spectorjs');
     DEBUG = true;
@@ -729,7 +729,7 @@ var WebGLRenderer = new Class({
         var canvas = this.canvas;
         var clearColor = config.backgroundColor;
 
-        if (DEBUG)
+        if (DEBUG && typeof SPECTOR !== 'undefined')
         {
             this.spector = new SPECTOR.Spector();
 


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Avoid generating errors if Phaser is loaded in an SSR environment.

Tested against Next.js 14.1.3.

Also includes fix for #6776 