### PR TITLE
Throw an error for invalid BitmapText key

### DIFF
--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -110,7 +110,7 @@ var BitmapText = new Class({
 
         if (!entry)
         {
-            console.warn('Invalid BitmapText key: ' + font);
+            throw new Error('Invalid BitmapText key: ' + font);
         }
 
         /**


### PR DESCRIPTION
If you create a BitmapText object with a bad key you see something like this in the console:

> [Warning] Invalid BitmapText key: font
> [Error] TypeError: undefined is not an object (evaluating 'entry.data')

Since the error is inevitable, I've replaced the console warning so there's now a single error message and trace:

> [Error] Invalid BitmapText key: font