### PR TITLE
Fix jsdoc in setWordWrapWidth from Text and TextStyle

### DIFF
--- a/src/gameobjects/text/Text.js
+++ b/src/gameobjects/text/Text.js
@@ -978,7 +978,7 @@ var Text = new Class({
      * @method Phaser.GameObjects.Text#setWordWrapWidth
      * @since 3.0.0
      *
-     * @param {?number} width - The maximum width of a line in pixels. Set to null to remove wrapping.
+     * @param {number | null} width - The maximum width of a line in pixels. Set to null to remove wrapping.
      * @param {boolean} [useAdvancedWrap=false] - Whether or not to use the advanced wrapping
      * algorithm. If true, spaces are collapsed and whitespace is trimmed from lines. If false,
      * spaces and whitespace are left as is.

--- a/src/gameobjects/text/TextStyle.js
+++ b/src/gameobjects/text/TextStyle.js
@@ -957,7 +957,7 @@ var TextStyle = new Class({
      * @method Phaser.GameObjects.TextStyle#setWordWrapWidth
      * @since 3.0.0
      *
-     * @param {number} width - The maximum width of a line in pixels. Set to null to remove wrapping.
+     * @param {number | null} width - The maximum width of a line in pixels. Set to null to remove wrapping.
      * @param {boolean} [useAdvancedWrap=false] - Whether or not to use the advanced wrapping
      * algorithm. If true, spaces are collapsed and whitespace is trimmed from lines. If false,
      * spaces and whitespace are left as is.


### PR DESCRIPTION
This PR

* Updates the JSDocumentation
* Fixes a bug

Describe the changes below:

I was using typescript phaser version when I found an issue with `Phaser.GameObjects.Text.setWordWrapWidth`, the method description says: params width - The maximum width of a line in pixels. **Set to null to remove wrapping.** 

So I tried to set it to null.
![image](https://github.com/phaserjs/phaser/assets/23361386/c854c4cf-90e3-4595-9123-0d303b1f4441)

But the following typescript error appeared. That's because the method jsdoc don't allow passing null, just undefined.
Reading the source code, I found that null is the correct value to pass here.

This PR changes the jsdoc to allow passing null to the method without errors.

I didn't generate the `.d.ts` definitions with `npm run tsgen`, which is something I think should be done by the maintainers of the project when new releases of the project are generated. Please do it after these changes.

I hope it helps, have a nice day!


