### PR TITLE
JSDoc and type for parent property

### DIFF
--- a/src/core/typedefs/GameConfig.js
+++ b/src/core/typedefs/GameConfig.js
@@ -7,7 +7,7 @@
  * @property {number} [zoom=1] - Simple scale applied to the game canvas. 2 is double size, 0.5 is half size, etc.
  * @property {number} [type=CONST.AUTO] - Which renderer to use. Phaser.AUTO, Phaser.CANVAS, Phaser.HEADLESS, or Phaser.WEBGL. AUTO picks WEBGL if available, otherwise CANVAS.
  * @property {(number|boolean)} [stableSort=-1] - `true` or `1` = Use the built-in StableSort (needed for older browsers), `false` or `0` = Rely on ES2019 Array.sort being stable (modern browsers only), or `-1` = Try and determine this automatically based on browser inspection (not guaranteed to work, errs on side of caution).
- * @property {(HTMLElement|string)} [parent=undefined] - The DOM element that will contain the game canvas, or its `id`. If undefined, or if the named element doesn't exist, the game canvas is appended to the document body. If `null` no parent will be used and you are responsible for adding the canvas to the dom.
+ * @property {(HTMLElement|string|null)} [parent=undefined] - The DOM element that will contain the game canvas, or its `id`. If undefined, or if the named element doesn't exist, the game canvas is appended to the document body. If `null` no parent will be used and you are responsible for adding the canvas to the dom.
  * @property {HTMLCanvasElement} [canvas=null] - Provide your own Canvas element for Phaser to use instead of creating one.
  * @property {string} [canvasStyle=null] - CSS styles to apply to the game canvas instead of Phasers default styles.
  * @property {boolean}[customEnvironment=false] - Is Phaser running under a custom (non-native web) environment? If so, set this to `true` to skip internal Feature detection. If `true` the `renderType` cannot be left as `AUTO`.


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR

* Updates JSDoc
* Fixes a bug

Describe the changes below:

I was using `typescript` and I found a mismatching property with `JSDoc` and `typescript`.
![image](https://github.com/phaserjs/phaser/assets/73399949/ac45923e-7331-43f8-8025-03d74954455d)
Here is the screenshot with `JSDoc` and an error from `typescript`.
I added `null` type for JSDoc.

Thank you!