### PR TITLE
Set gameSize equal to baseSize, for EXPAND scale mode

### DIFF
--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -1084,6 +1084,9 @@ var ScaleManager = new Class({
         }
         else if (this.scaleMode === CONST.SCALE_MODE.EXPAND)
         {
+            var baseWidth = this.game.config.width;
+            var baseHeight = this.game.config.height;
+
             //  Resize to match parent, like RESIZE mode
 
             //  This will constrain using min/max
@@ -1104,18 +1107,20 @@ var ScaleManager = new Class({
 
             // Expand canvas size to fit game size's width or height
 
-            var scaleX = this.parentSize.width / this.gameSize.width;
+            var scaleX = this.parentSize.width / baseWidth;
 
-            var scaleY = this.parentSize.height / this.gameSize.height;
+            var scaleY = this.parentSize.height / baseHeight;
 
             if (scaleX < scaleY)
             {
-                this.baseSize.setSize(this.gameSize.width, this.parentSize.height / scaleX);
+                this.baseSize.setSize(baseWidth, this.parentSize.height / scaleX);
             }
             else
             {
-                this.baseSize.setSize(this.displaySize.width / scaleY, this.gameSize.height);
+                this.baseSize.setSize(this.displaySize.width / scaleY, baseHeight);
             }
+
+            this.gameSize.setSize(this.baseSize.width, this.baseSize.height);
 
             styleWidth = this.baseSize.width;
             styleHeight = this.baseSize.height;

--- a/src/scale/index.js
+++ b/src/scale/index.js
@@ -24,6 +24,7 @@ var CONST = require('./const');
  * @borrows Phaser.Scale.ScaleModes.FIT as FIT
  * @borrows Phaser.Scale.ScaleModes.ENVELOP as ENVELOP
  * @borrows Phaser.Scale.ScaleModes.RESIZE as RESIZE
+ * @borrows Phaser.Scale.ScaleModes.EXPAND as EXPAND 
  *
  * @borrows Phaser.Scale.Zoom.NO_ZOOM as NO_ZOOM
  * @borrows Phaser.Scale.Zoom.ZOOM_2X as ZOOM_2X


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

gameSize is used for world bounds, cameras, set gameSize equal to baseSize, so that camera can render on whole game window.