### PR TITLE
Fixing DomElement position when camera zoom != 1

### DIFF
--- a/src/gameobjects/domelement/DOMElementCSSRenderer.js
+++ b/src/gameobjects/domelement/DOMElementCSSRenderer.js
@@ -85,7 +85,7 @@ var DOMElementCSSRenderer = function (renderer, src, camera, parentMatrix)
         dx = (src.width) * src.originX;
         dy = (src.height) * src.originY;
 
-        srcMatrix.applyITRS(src.x - dx, src.y - dy, src.rotation, src.scaleX, src.scaleY);
+        srcMatrix.applyITRS(src.x, src.y, src.rotation, src.scaleX, src.scaleY);
 
         camMatrix.copyFrom(camera.matrix);
 
@@ -97,6 +97,9 @@ var DOMElementCSSRenderer = function (renderer, src, camera, parentMatrix)
 
         //  Multiply by the src matrix, store result in calcMatrix
         camMatrix.multiply(srcMatrix, calcMatrix);
+
+        calcMatrix.e -= dx;
+        calcMatrix.f -= dy;
     }
 
     if (!src.transformOnly)


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

When the camera zoom is set to any other value than one, if a dom element origin if set to anything other than 0, the final position of the DOM was incorrect.

The complete bug is described in #6817.

I traced this back to the DOMElementCSSRenderer.
After some trial and error, I realized the translation needed to be applied after camera multiplication and not at the beginning.

With this change, DOMElements are correctly positioned.

This closes #6817 and https://github.com/workadventure/workadventure/issues/3936 (where you can see a video of the issue in action)


Note: I very much suspect the same error happens in the "if" clause, if a parent matrix is set. However, I don't know how to test this. Any help is welcome to help me test this out.