### PR TITLE
Fixes null @ currentBatch due flush() calls @ LightPipeline.js

### DIFF
--- a/src/renderer/webgl/pipelines/LightPipeline.js
+++ b/src/renderer/webgl/pipelines/LightPipeline.js
@@ -271,11 +271,6 @@ var LightPipeline = new Class({
         if (this.isNewNormalMap(texture, normalMap))
         {
             this.flush();
-
-            this.createBatch(texture);
-
-            this.addTextureToBatch(normalMap);
-
             this.currentNormalMap = normalMap;
         }
 
@@ -294,6 +289,12 @@ var LightPipeline = new Class({
 
         this.setNormalMapRotation(rotation);
 
+        if (this.currentBatch === null)
+        {
+	        this.createBatch(texture);
+	        this.addTextureToBatch(normalMap);
+        }
+        
         return 0;
     },
 
@@ -320,11 +321,6 @@ var LightPipeline = new Class({
         if (this.isNewNormalMap(texture, normalMap))
         {
             this.flush();
-
-            this.createBatch(texture);
-
-            this.addTextureToBatch(normalMap);
-
             this.currentNormalMap = normalMap;
         }
 
@@ -337,6 +333,12 @@ var LightPipeline = new Class({
         else
         {
             this.setNormalMapRotation(gameObject.rotation);
+        }
+
+        if (this.currentBatch === null)
+        {
+	        this.createBatch(texture);
+	        this.addTextureToBatch(normalMap);
         }
 
         return 0;


### PR DESCRIPTION
This PR: Fixes a bug

Test scenario:
1) Mesh gameobject -> .setPipeline('Light2D')
2) Applying a rotation to the mesh
The test might reveal an exception/crash due null values at currentBatch property of LightPipeline.
Crash flow: MeshWebGLRenderer -> setGameObject -> setNormalMapRotation -> flush

Rationale: setGameObject @ MeshWebGLRenderer invoking a flush @ setNormalMapRotation and making currentBatch=null.
The crash happens @ MeshWebGLRenderer  once reading a property on currentBatch (null).