### PR TITLE
Add TimeStep#pauseDuration, pass in Phaser.Core.Events#RESUME

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -630,7 +630,7 @@ var Game = new Class({
     {
         this.loop.resume();
 
-        this.events.emit(Events.RESUME);
+        this.events.emit(Events.RESUME, this.loop.pauseDuration);
     },
 
     /**

--- a/src/core/TimeStep.js
+++ b/src/core/TimeStep.js
@@ -305,6 +305,17 @@ var TimeStep = new Class({
         this.inFocus = true;
 
         /**
+         * The duration of the most recent game pause, if any, in ms.
+         *
+         * @name Phaser.Core.TimeStep#pauseDuration
+         * @type {number}
+         * @readonly
+         * @default 0
+         * @since 3.85.0
+         */
+        this.pauseDuration = 0;
+
+        /**
          * The timestamp at which the game became paused, as determined by the Page Visibility API.
          *
          * @name Phaser.Core.TimeStep#_pauseTime
@@ -469,7 +480,8 @@ var TimeStep = new Class({
     {
         this.resetDelta();
 
-        this.startTime += this.time - this._pauseTime;
+        this.pauseDuration = this.time - this._pauseTime;
+        this.startTime += this.pauseDuration;
     },
 
     /**

--- a/src/core/events/RESUME_EVENT.js
+++ b/src/core/events/RESUME_EVENT.js
@@ -12,5 +12,7 @@
  * @event Phaser.Core.Events#RESUME
  * @type {string}
  * @since 3.0.0
+ *
+ * @param {number} pauseDuration - The duration, in ms, that the game was paused for.
  */
 module.exports = 'resume';


### PR DESCRIPTION
This PR

* Adds a new feature

Some people want to use the pause interval, and you would have to calculate it yourself, even though TimeStep knows what it is. So I added. 

```js
this.game.events.on('resume', (pauseDuration) => {
  console.log('%s ms have passed', pauseDuration);
});
```

