### PR TITLE
Docs: correct args in some scene events

### DIFF
--- a/src/scene/events/POST_UPDATE_EVENT.js
+++ b/src/scene/events/POST_UPDATE_EVENT.js
@@ -26,7 +26,6 @@
  * @type {string}
  * @since 3.0.0
  *
- * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.
  * @param {number} delta - The delta time in ms since the last frame. This is a smoothed and capped value based on the FPS rate.
  */

--- a/src/scene/events/PRE_UPDATE_EVENT.js
+++ b/src/scene/events/PRE_UPDATE_EVENT.js
@@ -26,7 +26,6 @@
  * @type {string}
  * @since 3.0.0
  *
- * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.
  * @param {number} delta - The delta time in ms since the last frame. This is a smoothed and capped value based on the FPS rate.
  */

--- a/src/scene/events/UPDATE_EVENT.js
+++ b/src/scene/events/UPDATE_EVENT.js
@@ -26,7 +26,6 @@
  * @type {string}
  * @since 3.0.0
  *
- * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.
  * @param {number} delta - The delta time in ms since the last frame. This is a smoothed and capped value based on the FPS rate.
  */


### PR DESCRIPTION
This PR

* Updates the Documentation

`PRE_UPDATE`, `UPDATE`, `POST_UPDATE`

