### PR TITLE
Pass pauseDuration 0 in `Phaser.Core.Events#RESUME` after manual game resume

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -650,7 +650,7 @@ var Game = new Class({
 
         if (wasPaused)
         {
-            this.events.emit(Events.RESUME);
+            this.events.emit(Events.RESUME, 0);
         }
     },
 

--- a/src/core/events/RESUME_EVENT.js
+++ b/src/core/events/RESUME_EVENT.js
@@ -13,6 +13,6 @@
  * @type {string}
  * @since 3.0.0
  *
- * @param {number} pauseDuration - The duration, in ms, that the game was paused for.
+ * @param {number} pauseDuration - The duration, in ms, that the game was paused for, or 0 if {@link Phaser.Game#resume} was called.
  */
 module.exports = 'resume';


### PR DESCRIPTION
This PR

* Fixes a bug

After #6867, the other `RESUME` event (from calling `Phaser.Game#pause()`) also needed a `pauseDuration` argument. In this case it's `0` because the TimeStep wasn't actually paused.

