### PR TITLE
Allow ProcessCallback To Work When Dealing With Arcade Bodies That Do Not Have GameObjects

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1395,7 +1395,7 @@ var World = new Class({
         }
 
         //  They overlap. Is there a custom process callback? If it returns true then we can carry on, otherwise we should abort.
-        if (processCallback && processCallback.call(callbackContext, body1.gameObject, body2.gameObject) === false)
+        if (processCallback && processCallback.call(callbackContext, (body1.gameObject || body1), (body2.gameObject || body2)) === false)
         {
             return result;
         }

--- a/src/physics/arcade/typedefs/ArcadePhysicsCallback.js
+++ b/src/physics/arcade/typedefs/ArcadePhysicsCallback.js
@@ -11,6 +11,6 @@
  * 
  * You should only do this if the body intentionally has no associated game object (sprite, .etc).
  * 
- * @param {(Phaser.Types.Physics.Arcade.GameObjectWithBody|Phaser.Types.Physics.Arcade.Body|Phaser.Tilemaps.Tile)} object1 - The first Game Object.
- * @param {(Phaser.Types.Physics.Arcade.GameObjectWithBody|Phaser.Types.Physics.Arcade.Body|Phaser.Tilemaps.Tile)} object2 - The second Game Object.
+ * @param {(Phaser.Types.Physics.Arcade.GameObjectWithBody|Phaser.Physics.Arcade.Body|Phaser.Tilemaps.Tile)} object1 - The first Game Object.
+ * @param {(Phaser.Types.Physics.Arcade.GameObjectWithBody|Phaser.Physics.Arcade.Body|Phaser.Tilemaps.Tile)} object2 - The second Game Object.
  */

--- a/src/physics/arcade/typedefs/ArcadePhysicsCallback.js
+++ b/src/physics/arcade/typedefs/ArcadePhysicsCallback.js
@@ -7,6 +7,10 @@
  *
  * For all other cases, `object1` and `object2` match the same arguments in `collide()` or `overlap()`.
  *
- * @param {(Phaser.Types.Physics.Arcade.GameObjectWithBody|Phaser.Tilemaps.Tile)} object1 - The first Game Object.
- * @param {(Phaser.Types.Physics.Arcade.GameObjectWithBody|Phaser.Tilemaps.Tile)} object2 - The second Game Object.
+ * Note you can receive back only a body if you passed in a body directly.
+ * 
+ * You should only do this if the body intentionally has no associated game object (sprite, .etc).
+ * 
+ * @param {(Phaser.Types.Physics.Arcade.GameObjectWithBody|Phaser.Types.Physics.Arcade.Body|Phaser.Tilemaps.Tile)} object1 - The first Game Object.
+ * @param {(Phaser.Types.Physics.Arcade.GameObjectWithBody|Phaser.Types.Physics.Arcade.Body|Phaser.Tilemaps.Tile)} object2 - The second Game Object.
  */


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

Following up on a recent discussion in [the discord](https://discord.com/channels/244245946873937922/416623653741133837/1272581387068903424) / [this commit](https://github.com/phaserjs/phaser/commit/48f3769e5559aa392d43c6480478d9419d200e2a) this PR fixes a small bug in the `separate()` function. 

On these lines: https://github.com/phaserjs/phaser/blob/master/src/physics/arcade/World.js#L1946-L1950 - we see that the "detached" arcade body (the Body without a game object) is treated as a sprite (it `isBody` - unlike a sprite that has the body property `.body`) but in the processCallback this same dual nature of "sprite" in this context is not applied in reverse, the process callback will only pass back game objects, leading to potential bugs in consuming code trying to run a processCallback on their detached body colliders. This fix implements the same check in reverse, if the body has no gameObject (no sprite) the body itself will be returned to the callback, so that it can be executed/evaluated appropriately. 
