### PR TITLE
Add missing type defs to TweenChainBuilderConfig

### DIFF
--- a/src/tweens/typedefs/TweenChainBuilderConfig.js
+++ b/src/tweens/typedefs/TweenChainBuilderConfig.js
@@ -19,6 +19,8 @@
  * @property {array} [onStartParams] - Additional parameters to pass to `onStart`.
  * @property {Phaser.Types.Tweens.TweenOnStopCallback} [onStop] - A function to call when the chain is stopped.
  * @property {array} [onStopParams] - Additional parameters to pass to `onStop`.
+ * @property {Phaser.Types.Tweens.TweenOnUpdateCallback} [onUpdate] - A function to call each time the tween steps. Called once per property per target.
+ * @property {array} [onUpdateParams] - Additional parameters to pass to `onUpdate`.
  * @property {Phaser.Types.Tweens.TweenOnActiveCallback} [onActive] - A function to call when the chain becomes active within the Tween Manager.
  * @property {array} [onActiveParams] - Additional parameters to pass to `onActive`.
  * @property {Phaser.Types.Tweens.TweenOnPauseCallback} [onPause] - A function to call when the chain is paused.


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

Similar to [this](https://github.com/ospira/phaser/commit/48f3769e5559aa392d43c6480478d9419d200e2a), updated **`Phaser.Types.Tweens.TweenChainBuilderConfig`** typedef to match [this documentation](https://newdocs.phaser.io/docs/3.80.0/focus/Phaser.Types.Tweens.TweenChainBuilderConfig) (note the presence of `onUpdate` and `onUpdateParams`)

Note similarity with related class/def in both [typedef](https://github.com/ospira/phaser/blob/b331fe18403287fd09ebbb234dd510bf3f74e58f/src/tweens/typedefs/TweenBuilderConfig.js#L24-L34) and [documentation](https://newdocs.phaser.io/docs/3.80.0/focus/Phaser.Types.Tweens.TweenBuilderConfig)