### PR TITLE
fix(typedefs): fixing some typo error

### DIFF
--- a/src/cameras/2d/typedefs/JSONCamera.js
+++ b/src/cameras/2d/typedefs/JSONCamera.js
@@ -9,7 +9,7 @@
  * @property {number} height - The height size of camera
  * @property {number} zoom - The zoom of camera
  * @property {number} rotation - The rotation of camera
- * @property {boolean} roundPixels - The round pixels st status of camera
+ * @property {boolean} roundPixels - The round pixels indicate the status of the camera
  * @property {number} scrollX - The horizontal scroll of camera
  * @property {number} scrollY - The vertical scroll of camera
  * @property {string} backgroundColor - The background color of camera

--- a/src/core/Config.js
+++ b/src/core/Config.js
@@ -312,7 +312,7 @@ var Config = new Class({
         //  If you do: { banner: false } it won't display any banner at all
 
         /**
-         * @const {boolean} Phaser.Core.Config#hideBanner - Don't write the banner line to the console.log. See `Phaser.TYpes.Core.BannerConfig` for details of this object.
+         * @const {boolean} Phaser.Core.Config#hideBanner - Don't write the banner line to the console.log. See `Phaser.Types.Core.BannerConfig` for details of this object.
          */
         this.hideBanner = (GetValue(config, 'banner', null) === false);
 


### PR DESCRIPTION
This PR

* Updates the Documentation

## Describe the changes below:

Fixing two typedef typo errors
