### PR TITLE
Fix calculation of idx in GetBitmapTextSize

### DIFF
--- a/src/gameobjects/bitmaptext/GetBitmapTextSize.js
+++ b/src/gameobjects/bitmaptext/GetBitmapTextSize.js
@@ -162,6 +162,8 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
                     else
                     {
                         // If the current word is too long to fit on a line, wrap it
+                        // Remove trailing word wrap char to keep text length the same
+                        wrappedLine = wrappedLine.slice(0, -1);
                         wrappedLine += (wrappedLine ? '\n' : '') + lineToCheck;
                         lineToCheck = word;
                     }
@@ -170,6 +172,7 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
                 }
             }
 
+            wrappedLine = wrappedLine.slice(0, -1);
             wrappedLine += (wrappedLine ? '\n' : '') + lineToCheck;
             wrappedLines.push(wrappedLine);
         }

--- a/src/gameobjects/bitmaptext/GetBitmapTextSize.js
+++ b/src/gameobjects/bitmaptext/GetBitmapTextSize.js
@@ -176,80 +176,9 @@ var GetBitmapTextSize = function (src, round, updateOrigin, out)
 
         text = wrappedLines.join('\n');
 
-        //  Loop through the words array and see if we've got any > maxWidth
-        var prev;
-        var offset = 0;
-        var crs = [];
-
-        for (i = 0; i < words.length; i++)
-        {
-            var entry = words[i];
-            var left = entry.x;
-            var right = entry.x + entry.w;
-
-            if (left === 0)
-            {
-                offset = 0;
-                prev = null;
-            }
-
-            if (prev)
-            {
-                var diff = left - (prev.x + prev.w);
-
-                offset = left - (diff + prev.w);
-
-                prev = null;
-            }
-
-            var checkLeft = left - offset;
-            var checkRight = right - offset;
-
-            if (checkLeft > maxWidth || checkRight > maxWidth)
-            {
-                crs.push(entry.i - 1);
-
-                if (entry.cr)
-                {
-                    crs.push(entry.i + entry.word.length);
-
-                    offset = 0;
-                    prev = null;
-                }
-                else
-                {
-                    prev = entry;
-                }
-            }
-            else if (entry.cr)
-            {
-                crs.push(entry.i + entry.word.length);
-
-                offset = 0;
-                prev = null;
-            }
-        }
-
-        var stringInsert = function (str, index, value)
-        {
-            return str.substr(0, index) + value + str.substr(index + 1);
-        };
-
-        for (i = crs.length - 1; i >= 0; i--)
-        {
-            if (crs[i] > -1)
-            {
-                text = stringInsert(text, crs[i], '\n');
-            }
-        }
-        
         out.wrappedText = text;
 
         textLength = text.length;
-
-        //  Recalculated in the next loop
-        words = [];
-        current = null;
     }
 
     var charIndex = 0;


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

Fixes the way `BitmapTextCharacter.idx` is calculated in `GetBitmapTextSize` that is inconsistent with the docs and the behavior in 3.80 and before. This was caused by lines 165 and 173 changing the length of the text `idx` iterates over.
Code to demonstrate the bug: https://github.com/phaserjs/phaser/issues/6860#issuecomment-2334295340 
Also removed some code that was no longer used because it always iterates on an empty array.
Checked that it doesn't re-introduce the word-wrapping bug in #6860.