### PR TITLE
Make particle animation state optional

### DIFF
--- a/src/gameobjects/particles/Particle.js
+++ b/src/gameobjects/particles/Particle.js
@@ -330,11 +330,19 @@ var Particle = new Class({
          * It is responsible for playing, loading, queuing animations for later playback,
          * mixing between animations and setting the current animation frame to this Particle.
          *
+         * It is created only if the Particle's Emitter has at least one Animation.
+         *
          * @name Phaser.GameObjects.Particles.Particle#anims
-         * @type {Phaser.Animations.AnimationState}
+         * @type {?Phaser.Animations.AnimationState}
          * @since 3.60.0
+         * @see Phaser.GameObjects.Particles.ParticleEmitter#setAnim
          */
-        this.anims = new AnimationState(this);
+        this.anims = null;
+
+        if (this.emitter.anims.length > 0)
+        {
+            this.anims = new AnimationState(this);
+        }
 
         /**
          * A rectangle that holds the bounds of this Particle after a call to
@@ -590,7 +598,10 @@ var Particle = new Class({
             return false;
         }
 
-        this.anims.update(0, delta);
+        if (this.anims)
+        {
+            this.anims.update(0, delta);
+        }
 
         var emitter = this.emitter;
         var ops = emitter.ops;
@@ -783,7 +794,10 @@ var Particle = new Class({
      */
     destroy: function ()
     {
-        this.anims.destroy();
+        if (this.anims)
+        {
+            this.anims.destroy();
+        }
 
         this.anims = null;
         this.emitter = null;

--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -1377,6 +1377,8 @@ var ParticleEmitter = new Class({
      * anim: [ 'red', 'green', 'blue', 'pink', 'white' ]
      * anim: { anims: [ 'red', 'green', 'blue', 'pink', 'white' ], [cycle: bool], [quantity: int] }
      *
+     * Call this method at least once before any particles are created, or set `anim` in the Particle Emitter's configuration when creating the Emitter.
+     *
      * @method Phaser.GameObjects.Particles.ParticleEmitter#setAnim
      * @since 3.60.0
      *


### PR DESCRIPTION
This change creates `Phaser.GameObjects.Particles.Particle#anims` only if the particle's emitter has at least one animation.

This should reduce memory usage and make cleanup faster (#6482, #6929) for games using non-animated particles.

It is a breaking change for games adding a **first** animation to the emitter **after** some particles have already been created. That will now cause an error. But the usual approach for adding animations will work like before:

```js
this.add.particles(0, 0, 'explosion', {
  anim: ['explode']
  // ...
});
```
