### PR TITLE
fix type definitions for Matter CollisionActiveEvent | CollisionStartEvent | CollisionEnd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phaser",
-  "version": "3.80.0-beta.3",
+  "version": "3.86.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phaser",
-      "version": "3.80.0-beta.3",
+      "version": "3.86.1",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phaser",
-  "version": "3.86.1",
+  "version": "3.80.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phaser",
-      "version": "3.86.1",
+      "version": "3.80.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1"

--- a/src/physics/matter-js/events/COLLISION_ACTIVE_EVENT.js
+++ b/src/physics/matter-js/events/COLLISION_ACTIVE_EVENT.js
@@ -7,7 +7,7 @@
 /**
  * @typedef {object} Phaser.Physics.Matter.Events.CollisionActiveEvent
  *
- * @property {Phaser.Types.Physics.Matter.MatterCollisionData[]} pairs - A list of all affected pairs in the collision.
+ * @property {Phaser.Types.Physics.Matter.MatterCollisionPair[]} pairs - A list of all affected pairs in the collision.
  * @property {number} timestamp - The Matter Engine `timing.timestamp` value for the event.
  * @property {any} source - The source object of the event.
  * @property {string} name - The name of the event.

--- a/src/physics/matter-js/events/COLLISION_END_EVENT.js
+++ b/src/physics/matter-js/events/COLLISION_END_EVENT.js
@@ -7,7 +7,7 @@
 /**
  * @typedef {object} Phaser.Physics.Matter.Events.CollisionEndEvent
  *
- * @property {Phaser.Types.Physics.Matter.MatterCollisionData[]} pairs - A list of all affected pairs in the collision.
+ * @property {Phaser.Types.Physics.Matter.MatterCollisionPair[]} pairs - A list of all affected pairs in the collision.
  * @property {number} timestamp - The Matter Engine `timing.timestamp` value for the event.
  * @property {any} source - The source object of the event.
  * @property {string} name - The name of the event.

--- a/src/physics/matter-js/events/COLLISION_START_EVENT.js
+++ b/src/physics/matter-js/events/COLLISION_START_EVENT.js
@@ -7,7 +7,7 @@
 /**
  * @typedef {object} Phaser.Physics.Matter.Events.CollisionStartEvent
  *
- * @property {Phaser.Types.Physics.Matter.MatterCollisionData[]} pairs - A list of all affected pairs in the collision.
+ * @property {Phaser.Types.Physics.Matter.MatterCollisionPair[]} pairs - A list of all affected pairs in the collision.
  * @property {number} timestamp - The Matter Engine `timing.timestamp` value for the event.
  * @property {any} source - The source object of the event.
  * @property {string} name - The name of the event.


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR
* Fixes a bug

Describe the changes below:
- Edit JSDocs according to [this comment](https://github.com/phaserjs/phaser/pull/6936#issuecomment-2447058392)
- Generate typedefs with `npm run tsgen`, tested with `npm run test-ts`
