### PR TITLE
Fix getScene, getScenes return types.

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -847,6 +847,7 @@ var SceneManager = new Class({
      * @since 3.16.0
      *
      * @generic {Phaser.Scene[]} T - [$return]
+     * @genericUse {T} - [$return]
      *
      * @param {boolean} [isActive=true] - Only include Scene's that are currently active?
      * @param {boolean} [inReverse=false] - Return the array of Scenes in reverse?
@@ -885,6 +886,7 @@ var SceneManager = new Class({
      *
      * @generic {Phaser.Scene} T
      * @genericUse {(T|string)} - [key]
+     * @genericUse {T} - [$return]
      *
      * @param {(string|Phaser.Scene)} key - The key of the Scene to retrieve.
      *

--- a/src/scene/ScenePlugin.js
+++ b/src/scene/ScenePlugin.js
@@ -1022,6 +1022,7 @@ var ScenePlugin = new Class({
      *
      * @generic {Phaser.Scene} T
      * @genericUse {(T|string)} - [key]
+     * @genericUse {T} - [$return]
      *
      * @method Phaser.Scenes.ScenePlugin#get
      * @since 3.0.0


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

Since quite recently, the getScene methods don't return anything related to the generic anymore.

[Commit](https://github.com/phaserjs/phaser/commit/04f54b888a606d2b10ad5767833df435b1e89ca6) / [Issue #6821](https://github.com/phaserjs/phaser/issues/6821)

Therefore code like

```
const gameScene = game.scene.getScene<GameScene>(GameScene.key)
```

which used to cast `gameScene` as `GameScene` now returns it as a generic `Phaser.Scene`.

Now:
- type of `game.scene.getScene<GameScene>(GameScene.key)` is `GameScene`
- typeof `game.scene.getScenes<GameScene[]>()`  is `GameScene[]`
