### PR TITLE
Fix stream parameter type of video.loadMediaStream

### DIFF
--- a/src/gameobjects/video/Video.js
+++ b/src/gameobjects/video/Video.js
@@ -689,7 +689,7 @@ var Video = new Class({
      * @method Phaser.GameObjects.Video#loadMediaStream
      * @since 3.50.0
      *
-     * @param {string} stream - The MediaStream object.
+     * @param {MediaStream} stream - The MediaStream object.
      * @param {boolean} [noAudio=false] - Does the video have an audio track? If not you can enable auto-playing on it.
      * @param {string} [crossOrigin] - The value to use for the `crossOrigin` property in the video load request.  Either undefined, `anonymous` or `use-credentials`. If no value is given, `crossorigin` will not be set in the request.
      *


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Fix `stream` parameter type of `video.loadMediaStream`