### PR TITLE
Fix Arcade Physics Body destroy

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1846,7 +1846,7 @@ var Body = new Class({
 
         if (this.world)
         {
-            this.world.pendingDestroy.set(this);
+            this.world.pendingDestroy.add(this);
         }
     },
 

--- a/src/physics/arcade/StaticBody.js
+++ b/src/physics/arcade/StaticBody.js
@@ -890,7 +890,7 @@ var StaticBody = new Class({
     {
         this.enable = false;
 
-        this.world.pendingDestroy.set(this);
+        this.world.pendingDestroy.add(this);
     },
 
     /**


### PR DESCRIPTION
This PR

* Fixes a bug (v4.0.0-b.1)

There was an error destroying an Arcade Physics body:

> TypeError: this.world.pendingDestroy.set is not a function
