### PR TITLE
Fix TypeError when using scene injection map

### DIFF
--- a/src/gameobjects/components/Lighting.js
+++ b/src/gameobjects/components/Lighting.js
@@ -82,7 +82,7 @@ var Lighting = {
         {
             if (enabled === null)
             {
-                this.selfShadow.enabled = this.scene.game.config.selfShadow;
+                this.selfShadow.enabled = this.scene.sys.game.config.selfShadow;
             }
             else
             {

--- a/src/gameobjects/rope/RopeWebGLRenderer.js
+++ b/src/gameobjects/rope/RopeWebGLRenderer.js
@@ -46,7 +46,7 @@ var RopeWebGLRenderer = function (renderer, src, drawingContext, parentMatrix)
     }
     else
     {
-        smoothPixelArt = src.scene.game.config.smoothPixelArt;
+        smoothPixelArt = src.scene.sys.game.config.smoothPixelArt;
     }
     renderOptions.smoothPixelArt = smoothPixelArt;
 

--- a/src/renderer/webgl/renderNodes/submitter/SubmitterQuad.js
+++ b/src/renderer/webgl/renderNodes/submitter/SubmitterQuad.js
@@ -256,7 +256,7 @@ var SubmitterQuad = new Class({
             var selfShadowEnabled = selfShadow.enabled;
             if (selfShadowEnabled === null)
             {
-                selfShadowEnabled = gameObject.scene.game.config.selfShadow;
+                selfShadowEnabled = gameObject.scene.sys.game.config.selfShadow;
             }
 
             this._lightingOptions.normalGLTexture = normalMap;
@@ -280,7 +280,7 @@ var SubmitterQuad = new Class({
         }
         else
         {
-            smoothPixelArt = gameObject.scene.game.config.smoothPixelArt;
+            smoothPixelArt = gameObject.scene.sys.game.config.smoothPixelArt;
         }
         this._renderOptions.smoothPixelArt = smoothPixelArt;
     }

--- a/src/renderer/webgl/renderNodes/submitter/SubmitterTilemapGPULayer.js
+++ b/src/renderer/webgl/renderNodes/submitter/SubmitterTilemapGPULayer.js
@@ -391,7 +391,7 @@ var SubmitterTilemapGPULayer = new Class({
         var selfShadow = gameObject.selfShadow.enabled;
         if (selfShadow === null)
         {
-            selfShadow = gameObject.scene.game.config.selfShadow;
+            selfShadow = gameObject.scene.sys.game.config.selfShadow;
         }
         if (selfShadow)
         {
@@ -406,7 +406,7 @@ var SubmitterTilemapGPULayer = new Class({
         var smoothPixelArt = texture.smoothPixelArt;
         if (smoothPixelArt === null)
         {
-            smoothPixelArt = gameObject.scene.game.config.smoothPixelArt;
+            smoothPixelArt = gameObject.scene.sys.game.config.smoothPixelArt;
         }
         var smoothPixelArtAddition = programManager.getAddition('SmoothPixelArt');
         if (smoothPixelArtAddition)


### PR DESCRIPTION
This PR

* Fixes a bug (v4.0.0-beta.2)

When [a scene injection map](https://phaser.io/sandbox/zyjiE6in) is used, `scene.game` can be undefined and cause an error. I changed to `scene.sys.game`.

