### PR TITLE
Fix error rendering Matter Image/Sprite

### DIFF
--- a/src/physics/matter-js/MatterImage.js
+++ b/src/physics/matter-js/MatterImage.js
@@ -97,6 +97,7 @@ var MatterImage = new Class({
         this.setTexture(texture, frame);
         this.setSizeToFrame();
         this.setOrigin();
+        this.initRenderNodes(this._defaultRenderNodesMap);
 
         /**
          * A reference to the Matter.World instance that this body belongs to.

--- a/src/physics/matter-js/MatterSprite.js
+++ b/src/physics/matter-js/MatterSprite.js
@@ -103,6 +103,7 @@ var MatterSprite = new Class({
         this.setTexture(texture, frame);
         this.setSizeToFrame();
         this.setOrigin();
+        this.initRenderNodes(this._defaultRenderNodesMap);
 
         /**
          * A reference to the Matter.World instance that this body belongs to.


### PR DESCRIPTION
This PR

* Fixes a bug (4.0.0-beta.2)

There was an error rendering a Matter Image or Sprite, similar to

> [Error] TypeError: null is not an object (evaluating 'customRenderNodes.Submitter')
	SpriteWebGLRenderer (4.0.0-beta.2.js:77470)

I fixed this by calling `initRenderNodes()` in both constructors.