### PR TITLE
Use an optional chaining operator when calling preUpdate

### DIFF
--- a/src/gameobjects/UpdateList.js
+++ b/src/gameobjects/UpdateList.js
@@ -153,7 +153,7 @@ var UpdateList = new Class({
 
             if (gameObject.active)
             {
-                gameObject.preUpdate.call(gameObject, time, delta);
+                gameObject.preUpdate?.call(gameObject, time, delta);
             }
         }
     },


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

This simply ensures gameObject.preUpdate exists before attempting to `call` it. Doing so allows developers to forego the `preUpdate` method when creating custom GameObjects.

If we would prefer to avoid using an optional chaining operator, I can submit another pull request that instead checks for the existence of the method in the `if (gameObject.active)` conditional.

