### PR TITLE
Fix closest() and furthest()

### DIFF
--- a/src/physics/arcade/ArcadePhysics.js
+++ b/src/physics/arcade/ArcadePhysics.js
@@ -459,7 +459,7 @@ var ArcadePhysics = new Class({
     {
         if (!targets)
         {
-            targets = this.world.bodies.entries;
+            targets = Array.from(this.world.bodies);
         }
 
         var min = Number.MAX_VALUE;
@@ -513,7 +513,7 @@ var ArcadePhysics = new Class({
     {
         if (!targets)
         {
-            targets = this.world.bodies.entries;
+            targets = Array.from(this.world.bodies);
         }
 
         var max = -1;


### PR DESCRIPTION
This PR

* Fixes a bug (v4.0.0-beta.2)

Arcade Physics `closest()` and `furthest()` could error:

> [Error] TypeError: null is not an object (evaluating 'closest.center')

04694e3

