### PR TITLE
Fix Static Physics Group refresh

### DIFF
--- a/src/physics/arcade/StaticPhysicsGroup.js
+++ b/src/physics/arcade/StaticPhysicsGroup.js
@@ -209,7 +209,7 @@ var StaticPhysicsGroup = new Class({
      */
     refresh: function ()
     {
-        var children = this.children.entries;
+        var children = Array.from(this.children);
 
         for (var i = 0; i < children.length; i++)
         {


### PR DESCRIPTION
This PR

* Fixes a bug (v4.0.0)

`refresh()` was not affecting any bodies.
