### PR TITLE
Prevent matterjs stalls when returning to inactive tabs

### DIFF
--- a/src/physics/matter-js/World.js
+++ b/src/physics/matter-js/World.js
@@ -179,7 +179,8 @@ var World = new Class({
             isFixed: GetFastValue(runnerConfig, 'isFixed', false),
             delta: delta,
             deltaMin: deltaMin,
-            deltaMax: deltaMax
+            deltaMax: deltaMax,
+            maxFrameTime: 100
         };
 
         /**


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Fixes https://github.com/phaserjs/phaser/issues/6977

A more complete PR would include adding this to the type `Phaser.Types.Physics.Matter.MatterRunnerConfig`

This change limits the amount of time matterjs will be simulating after a tab is inactive for a long time. The number 100ms seems a reasonable maximum amount of time to wait for the game loop to resume.

Another issue with this PR is I don't understand why does src/physics/matter-js/World.js not use `Runner.create` as defined in src/physics/matter-js/lib/core/Runner.js but I'd rather someone that knows what's going on give an opinion on that.