### PR TITLE
Fix Matter World update, runner creation

### DIFF
--- a/src/physics/matter-js/World.js
+++ b/src/physics/matter-js/World.js
@@ -145,15 +145,9 @@ var World = new Class({
 
         var hasFPS = GetFastValue(runnerConfig, 'fps', false);
 
-        var fps = GetFastValue(runnerConfig, 'fps', 60);
-
-        var delta = GetFastValue(runnerConfig, 'delta', 1000 / fps);
-        var deltaMin = GetFastValue(runnerConfig, 'deltaMin', 1000 / fps);
-        var deltaMax = GetFastValue(runnerConfig, 'deltaMax', 1000 / (fps * 0.5));
-
-        if (!hasFPS)
+        if (hasFPS)
         {
-            fps = 1000 / delta;
+            runnerConfig.delta = 1000 / GetFastValue(runnerConfig, 'fps', 60);
         }
 
         /**
@@ -166,21 +160,7 @@ var World = new Class({
          * @type {Phaser.Types.Physics.Matter.MatterRunnerConfig}
          * @since 3.22.0
          */
-        this.runner = {
-            fps: fps,
-            deltaSampleSize: GetFastValue(runnerConfig, 'deltaSampleSize', 60),
-            counterTimestamp: 0,
-            frameCounter: 0,
-            deltaHistory: [],
-            timePrev: null,
-            timeScalePrev: 1,
-            frameRequestId: null,
-            timeBuffer: 0,
-            isFixed: GetFastValue(runnerConfig, 'isFixed', false),
-            delta: delta,
-            deltaMin: deltaMin,
-            deltaMax: deltaMax
-        };
+        this.runner = MatterRunner.create(runnerConfig);
 
         /**
          * Automatically call Engine.update every time the game steps.

--- a/src/physics/matter-js/lib/core/Runner.js
+++ b/src/physics/matter-js/lib/core/Runner.js
@@ -1,5 +1,5 @@
 /**
-* The `Matter.Runner` module is an optional utility which provides a game loop, 
+* The `Matter.Runner` module is an optional utility which provides a game loop,
 * that handles continuously updating a `Matter.Engine` for you within a browser.
 * It is intended for development and debugging purposes, but may also be suitable for simple games.
 * If you are using your own game loop instead, then you do not need the `Matter.Runner` module.
@@ -108,7 +108,7 @@ var Common = require('./Common');
 
             // limit delta
             var deltaHistoryWindow = runner.frameDeltaHistory.slice(
-                deltaHistorySorted.length * Runner._smoothingLowerBound, 
+                deltaHistorySorted.length * Runner._smoothingLowerBound,
                 deltaHistorySorted.length * Runner._smoothingUpperBound
             );
 
@@ -217,6 +217,7 @@ var Common = require('./Common');
         }
         return (result / valuesLength) || 0;
     };
+    Runner._mean = _mean;
     /*
     *
     *  Events Documentation
@@ -288,19 +289,7 @@ var Common = require('./Common');
      */
 
     /**
-     * A `Boolean` that specifies if the runner should use a fixed timestep (otherwise it is variable).
-     * If timing is fixed, then the apparent simulation speed will change depending on the frame rate (but behaviour will be deterministic).
-     * If the timing is variable, then the apparent simulation speed will be constant (approximately, but at the cost of determininism).
-     *
-     * @property isFixed
-     * @type boolean
-     * @default false
-     */
-
-    /**
      * A `Number` that specifies the time step between updates in milliseconds.
-     * If `engine.timing.isFixed` is set to `true`, then `delta` is fixed.
-     * If it is `false`, then `delta` can dynamically change to maintain the correct apparent simulation speed.
      *
      * @property delta
      * @type number

--- a/src/physics/matter-js/typedefs/MatterRunnerConfig.js
+++ b/src/physics/matter-js/typedefs/MatterRunnerConfig.js
@@ -1,12 +1,23 @@
 /**
+ * Configuration for the Matter Physics Runner.
+ *
+ * Set only one of `fps` and `delta`.
+ *
+ * `delta` is the size of the Runner's fixed time step (one physics update).
+ * The "frame delta" is the time elapsed since the last game step.
+ * Depending on the size of the frame delta, the Runner makes zero or more updates per game step.
+ *
  * @typedef {object} Phaser.Types.Physics.Matter.MatterRunnerConfig
  * @since 3.22.0
- *              
- * @property {boolean} [isFixed=false] - A boolean that specifies if the runner should use a fixed timestep (otherwise it is variable). If timing is fixed, then the apparent simulation speed will change depending on the frame rate (but behaviour will be deterministic). If the timing is variable, then the apparent simulation speed will be constant (approximately, but at the cost of determininism).
- * @property {number} [fps=60] - A number that specifies the frame rate in seconds. If you don't specify this, but do specify `delta`, those values set the fps rate.
- * @property {number} [correction=1] - A number that specifies the time correction factor to apply to the update. This can help improve the accuracy of the simulation in cases where delta is changing between updates.
- * @property {number} [deltaSampleSize=60] - The size of the delta smoothing array when `isFixed` is `false`.
- * @property {number} [delta=16.666] - A number that specifies the time step between updates in milliseconds. If you set the `fps` property, this value is set based on that. If `isFixed` is set to `true`, then `delta` is fixed. If it is `false`, then `delta` can dynamically change to maintain the correct apparent simulation speed.
- * @property {number} [deltaMin=16.666] - A number that specifies the minimum time step between updates in milliseconds.
- * @property {number} [deltaMax=33.333] - A number that specifies the maximum time step between updates in milliseconds.
+ *
+ * @property {number} [fps] - The number of physics updates per second. If set, this overrides `delta`.
+ * @property {number} [delta=16.666] - The size of the update time step in milliseconds. If `fps` is set, it overrides `delta`.
+ * @property {boolean} [frameDeltaSmoothing=true] - Whether to smooth the frame delta values.
+ * @property {boolean} [frameDeltaSnapping=true] - Whether to round the frame delta values to the nearest 1 Hz.
+ * @property {number} [frameDeltaHistorySize=100] - The number of frame delta values to record, when smoothing is enabled. The 10th to 90th percentiles are sampled.
+ * @property {number} [maxUpdates=null] - The maximum number of updates per frame.
+ * @property {number} [maxFrameTime=33.333] - The maximum amount of time to simulate in one frame, in milliseconds.
+ * @property {boolean} [enabled=true] - Whether the Matter Runner is enabled.
+ *
+ * @see Phaser.Physics.Matter.World#runner
  */


### PR DESCRIPTION
This PR

* Updates the Documentation
* Fixes a bug (Fixes #6977)

### Fixed

- `update()` was hanging the browser with large frame deltas.
- `update()` wasn't smoothing or snapping frame deltas.
- `physics.matter.runner` config values (except `delta` and `fps`) weren't being used.

Thanks @ubershmekel for identifying the cause of this problem.

### Docs

- Corrected [MatterRunnerConfig](https://docs.phaser.io/api-documentation/typedef/types-physics-matter#matterrunnerconfig).
- Removed `Runner.isFixed`.