### PR TITLE
Fail gracefully when a texture isn't created in `addBase64()`

### DIFF
--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -383,6 +383,11 @@ var TextureManager = new Class({
             {
                 var texture = _this.create(key, image);
 
+                if (!texture)
+                {
+                    return;
+                }
+
                 Parser.Image(texture, 0);
 
                 _this.emit(Events.ADD, key, texture);


### PR DESCRIPTION
This PR

* Fixes a bug

In `addBase64()`, `onload()` didn't handle a null result from `TextureManager#create()`, giving an error:

> TypeError: null is not an object (evaluating 'texture.source')

I changed it so `onload()` exits early without an error.

