### PR TITLE
Mouse events for unlocking Web Audio

### DIFF
--- a/src/sound/webaudio/WebAudioSoundManager.js
+++ b/src/sound/webaudio/WebAudioSoundManager.js
@@ -81,13 +81,16 @@ var WebAudioSoundManager = new Class({
 
         BaseSoundManager.call(this, game);
 
-        if (this.locked && game.isBooted)
+        if (this.locked)
         {
-            this.unlock();
-        }
-        else
-        {
-            game.events.once(GameEvents.BOOT, this.unlock, this);
+            if (game.isBooted)
+            {
+                this.unlock();
+            }
+            else
+            {
+                game.events.once(GameEvents.BOOT, this.unlock, this);
+            }
         }
     },
 

--- a/src/sound/webaudio/WebAudioSoundManager.js
+++ b/src/sound/webaudio/WebAudioSoundManager.js
@@ -322,7 +322,6 @@ var WebAudioSoundManager = new Class({
                     bodyRemove('touchend', unlockHandler);
                     bodyRemove('mousedown', unlockHandler);
                     bodyRemove('mouseup', unlockHandler);
-                    bodyRemove('click', unlockHandler);
                     bodyRemove('keydown', unlockHandler);
 
                     _this.unlocked = true;
@@ -333,7 +332,6 @@ var WebAudioSoundManager = new Class({
                     bodyRemove('touchend', unlockHandler);
                     bodyRemove('mousedown', unlockHandler);
                     bodyRemove('mouseup', unlockHandler);
-                    bodyRemove('click', unlockHandler);
                     bodyRemove('keydown', unlockHandler);
                 });
             }
@@ -345,7 +343,6 @@ var WebAudioSoundManager = new Class({
             body.addEventListener('touchend', unlockHandler, false);
             body.addEventListener('mousedown', unlockHandler, false);
             body.addEventListener('mouseup', unlockHandler, false);
-            body.addEventListener('click', unlockHandler, false);
             body.addEventListener('keydown', unlockHandler, false);
         }
     },

--- a/src/sound/webaudio/WebAudioSoundManager.js
+++ b/src/sound/webaudio/WebAudioSoundManager.js
@@ -77,7 +77,7 @@ var WebAudioSoundManager = new Class({
          */
         this.destination = this.masterMuteNode;
 
-        this.locked = this.context.state === 'suspended' && ('ontouchstart' in window || 'onclick' in window);
+        this.locked = this.context.state === 'suspended';
 
         BaseSoundManager.call(this, game);
 

--- a/src/sound/webaudio/WebAudioSoundManager.js
+++ b/src/sound/webaudio/WebAudioSoundManager.js
@@ -320,14 +320,19 @@ var WebAudioSoundManager = new Class({
                 {
                     bodyRemove('touchstart', unlockHandler);
                     bodyRemove('touchend', unlockHandler);
+                    bodyRemove('mousedown', unlockHandler);
+                    bodyRemove('mouseup', unlockHandler);
                     bodyRemove('click', unlockHandler);
                     bodyRemove('keydown', unlockHandler);
 
                     _this.unlocked = true;
+
                 }, function ()
                 {
                     bodyRemove('touchstart', unlockHandler);
                     bodyRemove('touchend', unlockHandler);
+                    bodyRemove('mousedown', unlockHandler);
+                    bodyRemove('mouseup', unlockHandler);
                     bodyRemove('click', unlockHandler);
                     bodyRemove('keydown', unlockHandler);
                 });
@@ -338,6 +343,8 @@ var WebAudioSoundManager = new Class({
         {
             body.addEventListener('touchstart', unlockHandler, false);
             body.addEventListener('touchend', unlockHandler, false);
+            body.addEventListener('mousedown', unlockHandler, false);
+            body.addEventListener('mouseup', unlockHandler, false);
             body.addEventListener('click', unlockHandler, false);
             body.addEventListener('keydown', unlockHandler, false);
         }


### PR DESCRIPTION
This PR makes an improvement:

Added `mousedown` and `mouseup` event listeners for unlocking Web Audio. Both events occur before existing `click` event, allowing for earlier audio unlocking on devices that use mouse.

