### PR TITLE
Prevent hanging timer events with repeat

### DIFF
--- a/src/time/Clock.js
+++ b/src/time/Clock.js
@@ -197,6 +197,11 @@ var Clock = new Class({
             event.elapsed = event.startAt;
             event.hasDispatched = false;
             event.repeatCount = (event.repeat === -1 || event.loop) ? 999999999999 : event.repeat;
+
+            if (event.delay <= 0 && event.repeatCount > 0)
+            {
+                throw new Error('TimerEvent infinite loop created via zero delay');
+            }
         }
         else
         {

--- a/src/time/TimerEvent.js
+++ b/src/time/TimerEvent.js
@@ -188,7 +188,7 @@ var TimerEvent = new Class({
         this.hasDispatched = false;
         this.repeatCount = (this.repeat === -1 || this.loop) ? 999999999999 : this.repeat;
 
-        if (this.delay === 0 && (this.repeat > 0 || this.loop))
+        if (this.delay <= 0 && this.repeatCount > 0)
         {
             throw new Error('TimerEvent infinite loop created via zero delay');
         }


### PR DESCRIPTION
This PR

* Fixes a bug

I improved the check in `TimerEvent#reset()` and added a check in `Clock#addEvent()`.

Fixes #7004.

