### PR TITLE
Add getDisplayList method to layer game object

### DIFF
--- a/src/gameobjects/layer/Layer.js
+++ b/src/gameobjects/layer/Layer.js
@@ -919,6 +919,38 @@ var Layer = new Class({
     },
 
     /**
+     * Returns a reference to the underlying display list _array_ that contains this Game Object,
+     * which will be either the Scene's Display List or the internal list belonging
+     * to its parent Container, if it has one.
+     * 
+     * If this Game Object is not on a display list or in a container, it will return `null`.
+     * 
+     * You should be very careful with this method, and understand that it returns a direct reference to the
+     * internal array used by the Display List. Mutating this array directly can cause all kinds of subtle
+     * and difficult to debug issues in your game.
+     *
+     * @method Phaser.GameObjects.Layer#getDisplayList
+     * @since 3.85.0
+     *
+     * @return {?Phaser.GameObjects.GameObject[]} The internal Display List array of Game Objects, or `null`.
+     */
+    getDisplayList: function ()
+    {
+        var list = null;
+
+        if (this.parentContainer)
+        {
+            list = this.parentContainer.list;
+        }
+        else if (this.displayList)
+        {
+            list = this.displayList.list;
+        }
+
+        return list;
+    },
+
+    /**
      * Destroys this Layer removing it from the Display List and Update List and
      * severing all ties to parent resources.
      *


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Layer game object does not extend from GameObject class, thus it does not have getDisplayList method. Copy this method from GameObject class. #7014 