### PR TITLE
Update Scene.js to clarify that scene properties are undefined in constructor

### DIFF
--- a/src/scene/Scene.js
+++ b/src/scene/Scene.js
@@ -37,6 +37,8 @@ var Scene = new Class({
 
         /**
          * A reference to the Phaser.Game instance.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -48,6 +50,8 @@ var Scene = new Class({
 
         /**
          * A reference to the global Animation Manager.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -59,6 +63,8 @@ var Scene = new Class({
 
         /**
          * A reference to the global Cache.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -70,6 +76,8 @@ var Scene = new Class({
 
         /**
          * A reference to the global Data Manager.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -81,6 +89,8 @@ var Scene = new Class({
 
         /**
          * A reference to the Sound Manager.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map and the plugin is installed.
          *
@@ -92,6 +102,8 @@ var Scene = new Class({
 
         /**
          * A reference to the Texture Manager.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -103,6 +115,8 @@ var Scene = new Class({
 
         /**
          * A Scene specific Event Emitter.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -114,6 +128,8 @@ var Scene = new Class({
 
         /**
          * The Scene Camera Manager.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -125,6 +141,8 @@ var Scene = new Class({
 
         /**
          * The Scene Game Object Factory.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -136,6 +154,8 @@ var Scene = new Class({
 
         /**
          * The Scene Game Object Creator.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -147,6 +167,8 @@ var Scene = new Class({
 
         /**
          * A reference to the Scene Manager Plugin.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -158,6 +180,8 @@ var Scene = new Class({
 
         /**
          * The Game Object Display List belonging to this Scene.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -169,6 +193,8 @@ var Scene = new Class({
 
         /**
          * The Scene Lights Manager Plugin.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map and the plugin is installed.
          *
@@ -180,6 +206,8 @@ var Scene = new Class({
 
         /**
          * A Scene specific Data Manager Plugin.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * See the `registry` property for the global Data Manager.
          *
@@ -193,6 +221,8 @@ var Scene = new Class({
 
         /**
          * The Scene Input Manager Plugin.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map and the plugin is installed.
          *
@@ -204,6 +234,8 @@ var Scene = new Class({
 
         /**
          * The Scene Loader Plugin.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map and the plugin is installed.
          *
@@ -215,6 +247,8 @@ var Scene = new Class({
 
         /**
          * The Scene Time and Clock Plugin.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map and the plugin is installed.
          *
@@ -226,6 +260,8 @@ var Scene = new Class({
 
         /**
          * The Scene Tween Manager Plugin.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map and the plugin is installed.
          *
@@ -237,6 +273,8 @@ var Scene = new Class({
 
         /**
          * The Scene Arcade Physics Plugin.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map, the plugin is installed and configured.
          *
@@ -248,6 +286,8 @@ var Scene = new Class({
 
         /**
          * The Scene Matter Physics Plugin.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map, the plugin is installed and configured.
          *
@@ -261,6 +301,8 @@ var Scene = new Class({
         {
             /**
              * The Facebook Instant Games Plugin.
+             * 
+             * Note: will be undefined in scene's constructor.
              *
              * This property will only be available if defined in the Scene Injection Map, the plugin is installed and configured.
              *
@@ -273,6 +315,8 @@ var Scene = new Class({
 
         /**
          * A reference to the global Scale Manager.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * This property will only be available if defined in the Scene Injection Map.
          *
@@ -284,6 +328,8 @@ var Scene = new Class({
 
         /**
          * A reference to the global Plugin Manager.
+         * 
+         * Note: will be undefined in scene's constructor.
          *
          * The Plugin Manager is a global system that allows plugins to register themselves with it, and can then install
          * those plugins into Scenes as required.
@@ -296,6 +342,8 @@ var Scene = new Class({
 
         /**
          * A reference to the renderer instance Phaser is using, either Canvas Renderer or WebGL Renderer.
+         * 
+         *  Note: will be undefined in scene's constructor.
          *
          * @name Phaser.Scene#renderer
          * @type {(Phaser.Renderer.Canvas.CanvasRenderer|Phaser.Renderer.WebGL.WebGLRenderer)}


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:

When one is extending a scene, one might expect to be able to do something like the following (based on current docs):

```
export class MainScene extends Phaser.Scene {
  somethingYouWantFromTheRegistry: any;

  // other custom properties
  systems: Array<
    new (scene: BaseScene, key: string, ...args: any) => BaseSystem
  >;
  //...

  constructor() {
    super("MainScene"); // you might reasonably expect Phaser.Scene properties to be set at this point

    // set custom properties
    this.systems = [PathFindingSystem, EmoteSystem];
    const registry = this.registry;
    console.log({ registry }); // !returns undefined unexpectedly
    this.somethingYouWantFromTheRegistry = this.registry.get("blah blah blah"); // ! causes error and user to go... why!?
  }
  create() {
    const registry = this.registry; // but down here it actually returns the game registry (even though user didn't do anything)
    this.somethingYouWantFromTheRegistry = this.registry.get("blah blah blah"); // so it "just works" down here
  }
}

```

The reason for this is understandable once you dive into the source code, which uses a custom class implementation instead of default ES6 classes/extend, although most users will be using the default classes in their code. Based on my understanding of this code, the reason for properties like `registry` not being available in the constructor is because the Scene class relies on the `SceneManager.add()` to actually fill these properties, once the Scene has already been instantiated.

However, if you're just a dev consuming this API, that isn't clear in the current documentation. To figure out why the above works relies on navigating the Phaser source code, understanding the custom class/inheritance implementation and then looking at `SceneManager` which as mentioned in its own docs should [usually not be interacted with directly at all](https://github.com/phaserjs/phaser/blob/master/src/scene/SceneManager.js#L24).

Furthermore, the current docs might muddle the matter because they mention _property unavailability_ in reference to the _Scene Injection Map_, which might cause a developer to try to figure out what that is, when that has nothing to do with this constructor issue.

All in all this is a minor doc addendum, but hopefully one that seems worthy of accepting, if only to save the next poor sap from getting very derailed by this 😅 (and questioning their basic understanding of how classes work in javascript or what the scene injection map is before realizing what was actually going on here 😵).

Thanks! :D