### PR TITLE
[Phaser 4] Fix missing reference to Renderer events in BatchHandler

### DIFF
--- a/src/renderer/webgl/renderNodes/BatchHandler.js
+++ b/src/renderer/webgl/renderNodes/BatchHandler.js
@@ -8,6 +8,7 @@ var Class = require('../../../utils/Class');
 var ProgramManager = require('../ProgramManager');
 var WebGLVertexBufferLayoutWrapper = require('../wrappers/WebGLVertexBufferLayoutWrapper');
 var RenderNode = require('./RenderNode');
+var Renderer = require('../../../renderer');
 
 /**
  * @classdesc
@@ -119,7 +120,7 @@ var BatchHandler = new Class({
 
         // Listen for changes to the number of draw calls per batch.
         this.manager.on(
-            Phaser.Renderer.Events.SET_PARALLEL_TEXTURE_UNITS,
+            Renderer.Events.SET_PARALLEL_TEXTURE_UNITS,
             this.updateTextureCount,
             this
         );
@@ -257,7 +258,7 @@ var BatchHandler = new Class({
 
         // Set the dimension-related uniforms and listen for resize events.
         this.resize(renderer.width, renderer.height);
-        renderer.on(Phaser.Renderer.Events.RESIZE, this.resize, this);
+        renderer.on(Renderer.Events.RESIZE, this.resize, this);
     },
 
     /**


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

In phaser 4.0.0, the new BatchHandler.js file has some references to `Phaser` in the global context. This PR fixes the missing references.