### PR TITLE
[Phaser 4] Fix some JSDoc errors

### DIFF
--- a/src/renderer/webgl/renderNodes/BatchHandlerStrip.js
+++ b/src/renderer/webgl/renderNodes/BatchHandlerStrip.js
@@ -142,7 +142,7 @@ var BatchHandlerStrip = new Class({
      * @param {Uint32Array} colors - The color values of the strip.
      * @param {Float32Array} alphas - The alpha values of the strip.
      * @param {number} alpha - The overall alpha value of the strip.
-     * @param {number} tintFill - Whether to tint the fill color.
+     * @param {boolean} tintFill - Whether to tint the fill color.
      * @param {Phaser.Types.Renderer.WebGL.RenderNodes.BatchHandlerQuadRenderOptions} renderOptions - Optional render features. Strip rendering should always set `multiTexturing` to false. It can use `smoothPixelArt`. Other options are ignored.
      * @param {function} [debugCallback] - The debug callback, called with an array consisting of alternating x,y values of the transformed vertices.
      */

--- a/src/renderer/webgl/renderNodes/BatchHandlerTileSprite.js
+++ b/src/renderer/webgl/renderNodes/BatchHandlerTileSprite.js
@@ -178,7 +178,7 @@ var BatchHandlerTileSprite = new Class({
      * @param {number} texY - The top v coordinate (0-1).
      * @param {number} texWidth - The width of the texture (0-1).
      * @param {number} texHeight - The height of the texture (0-1).
-     * @param {number} tintFill - Whether to tint the fill color.
+     * @param {boolean} tintFill - Whether to tint the fill color.
      * @param {number} tintTL - The tint color for the top-left corner.
      * @param {number} tintBL - The tint color for the bottom-left corner.
      * @param {number} tintTR - The tint color for the top-right corner.

--- a/src/renderer/webgl/renderNodes/RenderNodeManager.js
+++ b/src/renderer/webgl/renderNodes/RenderNodeManager.js
@@ -247,9 +247,9 @@ var RenderNodeManager = new Class({
     /**
      * Add a node to the manager.
      *
-     * @method Phaser.Renderer.WebGL.RenderNodes.RenderNodeManager#addStep
+     * @method Phaser.Renderer.WebGL.RenderNodes.RenderNodeManager#addNode
      * @since 4.0.0
-     * @param {string} name - The name of the step.
+     * @param {string} name - The name of the node.
      * @param {Phaser.Renderer.WebGL.RenderNodes.RenderNode} node - The node to add.
      * @throws {Error} Will throw an error if the node already exists.
      */


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:

- Fixed JSDoc for `RenderNodeManager#addNode` (method was incorrectly named `addStep` in the doc comment)
- Fixed a mis-type of two batch methods which thought `tintFill` was a number when it should be a boolean.
