### PR TITLE
Fix imageCollections default Tileset values

### DIFF
--- a/src/tilemaps/parsers/tiled/BuildTilesetIndex.js
+++ b/src/tilemaps/parsers/tiled/BuildTilesetIndex.js
@@ -35,7 +35,7 @@ var BuildTilesetIndex = function (mapData)
                 y: image.height - mapData.tileHeight
             };
             
-            set = new Tileset(image.image, image.gid, image.width, image.height, 0, 0, null, null, offset);
+            set = new Tileset(image.image, image.gid, image.width, image.height, 0, 0, undefined, undefined, offset);
 
             set.updateTileData(image.width, image.height);
 


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:

A recent change (a763d77) prevents the default values for Tileset's tileProperties and tileData from being set because it passes `null` instead of `undefined` for those [constructor args](https://github.com/phaserjs/phaser/blob/b73965652a715932f2f52f6bd53367edca9427c2/src/tilemaps/Tileset.js#L35).

This restores those default values, eliminating an `Uncaught TypeError: Cannot read properties of null` error [here](https://github.com/phaserjs/phaser/blob/b73965652a715932f2f52f6bd53367edca9427c2/src/tilemaps/Tileset.js#L214) when using ImageCollections.

I rolled back my phaser version from 3.88 to 3.87 (before the above changes) and the error was gone.