### PR TITLE
Throw an error for missing DOM Container

### DIFF
--- a/src/gameobjects/domelement/DOMElement.js
+++ b/src/gameobjects/domelement/DOMElement.js
@@ -130,6 +130,11 @@ var DOMElement = new Class({
          */
         this.parent = scene.sys.game.domContainer;
 
+        if (!this.parent)
+        {
+            throw new Error('No DOM Container');
+        }
+
         /**
          * A reference to the HTML Cache.
          *
@@ -633,10 +638,7 @@ var DOMElement = new Class({
 
         target.phaser = this;
 
-        if (this.parent)
-        {
-            this.parent.appendChild(target);
-        }
+        this.parent.appendChild(target);
 
         //  InnerText
 
@@ -748,10 +750,7 @@ var DOMElement = new Class({
 
         element.phaser = this;
 
-        if (this.parent)
-        {
-            this.parent.appendChild(element);
-        }
+        this.parent.appendChild(element);
 
         element.innerHTML = html;
 


### PR DESCRIPTION
This PR

* Adds a new feature

Previously Phaser would silently abort `add.dom()` if `game.domContainer` was empty. Now it throws an error instead:

> No DOM Container
