### PR TITLE
Fix particle emitter custom moveTo functions

### DIFF
--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -17,6 +17,7 @@ var GameObject = require('../GameObject');
 var GetFastValue = require('../../utils/object/GetFastValue');
 var GetRandom = require('../../utils/array/GetRandom');
 var GravityWell = require('./GravityWell');
+var HasAll = require('../../utils/object/HasAll');
 var HasAny = require('../../utils/object/HasAny');
 var HasValue = require('../../utils/object/HasValue');
 var Inflate = require('../../geom/rectangle/Inflate');
@@ -978,7 +979,7 @@ var ParticleEmitter = new Class({
 
         this.acceleration = (this.accelerationX !== 0 || this.accelerationY !== 0);
 
-        this.moveTo = (this.moveToX !== 0 && this.moveToY !== 0);
+        this.moveTo = HasAll(config, [ 'moveToX', 'moveToY' ]);
 
         //  Special 'speed' override
 


### PR DESCRIPTION
This PR

* Fixes a bug

Fixes #7063.

This also allows `{ moveToX: 0, moveToY: 0 }` to work.


