### PR TITLE
Clear EmitterColorOp RGB arrays before repopulating

### DIFF
--- a/src/gameobjects/particles/EmitterColorOp.js
+++ b/src/gameobjects/particles/EmitterColorOp.js
@@ -116,6 +116,10 @@ var EmitterColorOp = new Class({
 
             this.active = true;
 
+            this.r.length = 0;
+            this.g.length = 0;
+            this.b.length = 0;
+
             //  Populate the r,g,b arrays
             for (var i = 0; i < value.length; i++)
             {


### PR DESCRIPTION
This PR

* Fixes a bug

Calling `updateConfig()` or `setConfig()` with a `color` ease would halve the ease period each time (https://phaser.io/sandbox/YSJesSAQ).

Fixes #7069. 
