### PR TITLE
Fix missing types for Filters component

### DIFF
--- a/src/gameobjects/GameObject.js
+++ b/src/gameobjects/GameObject.js
@@ -21,6 +21,7 @@ var SceneEvents = require('../scene/events');
  * @class GameObject
  * @memberof Phaser.GameObjects
  * @extends Phaser.Events.EventEmitter
+ * @extends Phaser.GameObjects.Components.Filters
  * @constructor
  * @since 3.0.0
  *


### PR DESCRIPTION
* Updates the Documentation
* Fixes a bug

Small update in doc for GameObject.js. In Phaser 4.0.0 it newly uses Filter component, but was missing  @<!-- -->extends tag for this component in doc.

Therefore, there was missing Filters interface implementation in GameObject class in generated Typescript defs. And it was not possible to use enableFilters() in Typescript code.

(I hope this is the right way how to fix the missing type defs...)

