### PR TITLE
TypeScript: Missing property 'cache' in FileConfig

### DIFF
--- a/src/loader/typedefs/FileConfig.js
+++ b/src/loader/typedefs/FileConfig.js
@@ -3,6 +3,7 @@
  * @since 3.0.0
  *
  * @property {string} type - The name of the Loader method that loads this file, e.g., 'image', 'json', 'spritesheet'.
+ * @property {(Phaser.Cache.BaseCache|false)} cache - Reference to the cache instance responsible for this file type. Or false if you don't need to retrieve files from your game; e.g.: Font files tracked by the browser.
  * @property {string} key - Unique cache key (unique within its file type)
  * @property {object|string} [url] - The URL of the file, not including baseURL.
  * @property {string} [path] - The path of the file, not including the baseURL.


### PR DESCRIPTION
This PR:

* Fixes a bug

Describe the changes below:

- Add the missing 'cache' property in the FileConfig type definition.

Reasoning:

I didn't make this property optional to force user being conscious that a non cached file will be of no use in the majority of cases.

