### PR TITLE
Fix bounds calculation in getFrameBounds

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -343,7 +343,7 @@ var Texture = new Class({
         var maxX = baseFrame.cutX + baseFrame.cutWidth;
         var maxY = baseFrame.cutY + baseFrame.cutHeight;
 
-        for (var i = 1; i < frames.length; i++)
+        for (var i = 1; i < frames.length - 1; i++)
         {
             var frame = frames[i];
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
The range of the loop in *Texture#getFrameBounds* has been adjusted to not include the last frame (__BASE), as it caused an incorrect calculation of the bounds (allways {x:0, y:0, w: textureWidth, h: textureHight}).  
You can see the problem in this code: https://phaser.io/sandbox/tqnwvEda . If the texture comes from an atlas frame, the framebounds of the texture should be the same as the bounds of the atlas frame.

