### PR TITLE
Fix Camera rotateTo() and change destination argument

### DIFF
--- a/src/cameras/2d/Camera.js
+++ b/src/cameras/2d/Camera.js
@@ -442,27 +442,26 @@ var Camera = new Class({
     },
 
     /**
-     * This effect will rotate the Camera so that the viewport finishes at the given angle in radians,
-     * over the duration and with the ease specified.
+     * Rotate the Camera to the given angle over the duration and with the ease specified.
      *
      * @method Phaser.Cameras.Scene2D.Camera#rotateTo
      * @since 3.23.0
      *
-     * @param {number} radians - The destination angle in radians to rotate the Camera viewport to. If the angle is positive then the rotation is clockwise else anticlockwise
-     * @param {boolean} [shortestPath=false] - If shortest path is set to true the camera will rotate in the quickest direction clockwise or anti-clockwise.
+     * @param {number} angle - The destination angle in radians to rotate the Camera view to.
+     * @param {boolean} [shortestPath=false] - If true, take the shortest distance to the destination. This adjusts the destination angle to be within one half turn of the start angle.
      * @param {number} [duration=1000] - The duration of the effect in milliseconds.
-     * @param {(string|function)} [ease='Linear'] - The ease to use for the rotation. Can be any of the Phaser Easing constants or a custom function.
+     * @param {(string|function)} [ease='Linear'] - The ease to use. Can be any of the Phaser Easing constants or a custom function.
      * @param {boolean} [force=false] - Force the rotation effect to start immediately, even if already running.
-     * @param {CameraRotateCallback} [callback] - This callback will be invoked every frame for the duration of the effect.
-     * It is sent four arguments: A reference to the camera, a progress amount between 0 and 1 indicating how complete the effect is,
-     * the current camera rotation angle in radians.
+     * @param {Phaser.Types.Cameras.Scene2D.CameraRotateCallback} [callback] - This callback will be invoked every frame for the duration of the effect.
+     * It is sent three arguments: A reference to the camera, a progress amount between 0 and 1 indicating how complete the effect is,
+     * and the current camera rotation.
      * @param {any} [context] - The context in which the callback is invoked. Defaults to the Scene to which the Camera belongs.
      *
      * @return {Phaser.Cameras.Scene2D.Camera} This Camera instance.
      */
-    rotateTo: function (radians, shortestPath, duration, ease, force, callback, context)
+    rotateTo: function (angle, shortestPath, duration, ease, force, callback, context)
     {
-        return this.rotateToEffect.start(radians, shortestPath, duration, ease, force, callback, context);
+        return this.rotateToEffect.start(angle, shortestPath, duration, ease, force, callback, context);
     },
 
     /**

--- a/src/cameras/2d/typedefs/CameraRotateCallback.js
+++ b/src/cameras/2d/typedefs/CameraRotateCallback.js
@@ -1,0 +1,8 @@
+/**
+ * @callback Phaser.Types.Cameras.Scene2D.CameraRotateCallback
+ * @since 3.23.0
+ *
+ * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera on which the effect is running.
+ * @param {number} progress - The progress of the effect. A value between 0 and 1.
+ * @param {number} rotation - The Camera's new rotation in radians.
+ */


### PR DESCRIPTION
This PR

* Adds a new feature (breaking change)
* Fixes a bug

I started fixing #7090 and ended up changing the destination argument.

### Updates (breaking change)

In Phaser 3's [Camera.rotateTo()](https://docs.phaser.io/api-documentation/class/cameras-scene2d-camera#rotateto), when the `shortestPath` argument was `false` (the default value), the sign of the `radians` argument indicated the direction of rotation and the absolute value of the `radians` argument indicated the destination angle. In Phaser 4, the `radians` argument is now called `angle` and represents the destination angle as a signed value. You can use the new functions `Phaser.Math.Angle.GetClockwiseDistance()` or `Phaser.Math.Angle.GetCounterClockwiseDistance()` to calculate rotation distances in a specific direction.

### Bug Fixes

- Fixes #7090 


