### PR TITLE
Update ArcadeColliderType.js

### DIFF
--- a/src/physics/arcade/typedefs/ArcadeColliderType.js
+++ b/src/physics/arcade/typedefs/ArcadeColliderType.js
@@ -1,6 +1,6 @@
 /**
  * An Arcade Physics Collider Type.
  *
- * @typedef {(Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody|Phaser.GameObjects.GameObject|Phaser.GameObjects.Group|Phaser.Physics.Arcade.Sprite|Phaser.Physics.Arcade.Image|Phaser.Physics.Arcade.StaticGroup|Phaser.Physics.Arcade.Group|Phaser.Tilemaps.TilemapLayer|Phaser.Physics.Arcade.Body[]|Phaser.GameObjects.GameObject[]|Phaser.Physics.Arcade.Sprite[]|Phaser.Physics.Arcade.Image[]|Phaser.Physics.Arcade.StaticGroup[]|Phaser.Physics.Arcade.Group[]|Phaser.Tilemaps.TilemapLayer[])} Phaser.Types.Physics.Arcade.ArcadeColliderType
+ * @typedef {(Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody|Phaser.GameObjects.GameObject|Phaser.GameObjects.Group|Phaser.Physics.Arcade.Sprite|Phaser.Physics.Arcade.Image|Phaser.Physics.Arcade.StaticGroup|Phaser.Physics.Arcade.Group|Phaser.Tilemaps.TilemapLayer|Array.<Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody|Phaser.GameObjects.GameObject|Phaser.GameObjects.Group|Phaser.Physics.Arcade.Sprite|Phaser.Physics.Arcade.Image|Phaser.Physics.Arcade.StaticGroup|Phaser.Physics.Arcade.Group|Phaser.Tilemaps.TilemapLayer>)} Phaser.Types.Physics.Arcade.ArcadeColliderType
  * @since 3.0.0
  */


### PR DESCRIPTION
This PR

* Updates the Documentation
* Fixes a bug

Describe the changes below:

`ArcadeColliderType` typedef/jsdoc is mildly incorrect. The array versions of this type do not need to be of a single type (see collider code [here](https://github.com/phaserjs/phaser/blob/master/src/physics/arcade/World.js#L1816) for example) but rather if it's an array that array can be a mix of any of the various single types, as https://github.com/phaserjs/phaser/blob/master/src/physics/arcade/World.js#L1934 is going to test each member of the array anyway. Note, this still works if you pass an array of a single type, it just doesn't force you to do that, as it isn't actually necessary. 