### PR TITLE
Fix GetCounterClockwiseDistance() for Phaser 3

### DIFF
--- a/src/math/angle/GetCounterClockwiseDistance.js
+++ b/src/math/angle/GetCounterClockwiseDistance.js
@@ -4,10 +4,9 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
-var MATH_CONST = require('../const');
 var NormalizeAngle = require('./Normalize');
 
-var TAU = MATH_CONST.TAU;
+var TAU = 2 * Math.PI;
 
 /**
  * Gets the shortest nonpositive angular distance from angle1 to angle2.


### PR DESCRIPTION
This PR

* Fixes a bug (bedf81aa72d23b1c1b9d9bfaa31611ef9d15e0d0)

Needs the correct `TAU` (1 turn) in Phaser 3. Phaser 4 branch works correctly.
