### PR TITLE
Fix JSDocs return type of `Phaser.Tweens.Tween#getValue`

### DIFF
--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -242,7 +242,7 @@ var Tween = new Class({
      *
      * @param {number} [index=0] - The Tween Data to return the value from.
      *
-     * @return {number} The value of the requested Tween Data, or `null` if this Tween has been destroyed.
+     * @return {number|null} The value of the requested Tween Data, or `null` if this Tween has been destroyed.
      */
     getValue: function (index)
     {


### PR DESCRIPTION
This PR:
* Updates the Documentation

Describe the changes below:

The return type of `Phaser.Tweens.Tween#getValue` is changed from `number` to `number|null` to reflect its actual return types.
