### PR TITLE
Add missing thisValue for forEach

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -723,7 +723,7 @@ var Group = new Class({
                 gameObject.removeFromDisplayList();
                 gameObject.removeFromUpdateList();
             }
-        });
+        }, this);
 
         children.clear();
 

--- a/src/physics/arcade/StaticPhysicsGroup.js
+++ b/src/physics/arcade/StaticPhysicsGroup.js
@@ -77,7 +77,7 @@ var StaticPhysicsGroup = new Class({
                 singleConfig.internalRemoveCallback = this.removeCallbackHandler;
                 singleConfig.createMultipleCallback = this.createMultipleCallbackHandler;
                 singleConfig.classType = GetFastValue(singleConfig, 'classType', ArcadeSprite);
-            });
+            }, this);
         }
         else
         {


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

this value was accessed inside the functions in forEach, but the value for this was not provided.
I noticed that in some places var _this = this approach is used for that and in some places this is added as the second parameter of forEach. I added this as the second parameter of forEach to fix that. Maybe it would be good to make it the same everywhere.

