### PR TITLE
fix TypeError in Chrome from GamepadPlugin.stopListeners. It is calli…

### DIFF
--- a/src/input/gamepad/GamepadPlugin.js
+++ b/src/input/gamepad/GamepadPlugin.js
@@ -300,7 +300,9 @@ var GamepadPlugin = new Class({
 
         for (var i = 0; i < this.gamepads.length; i++)
         {
-            this.gamepads[i].removeAllListeners();
+            if (this.gamepads[i]) {
+                this.gamepads[i].removeAllListeners();
+            }
         }
     },
 


### PR DESCRIPTION
…ng the removeAllListeners method on `undefined`.

This PR

* Fixes a bug

The gamepad plugin's gamepads array sometimes has undefined values in it, especially in Chrome.  Here is a stack trace:

```
Cannot read properties of undefined (reading 'removeAllListeners')
TypeError: Cannot read properties of undefined (reading 'removeAllListeners')
    at GamepadPlugin.stopListeners (webpack-internal:///./node_modules/phaser/dist/phaser.js:112078:30)
    at GamepadPlugin.shutdown (webpack-internal:///./node_modules/phaser/dist/phaser.js:112275:14)
    at EventEmitter.emit (webpack-internal:///./node_modules/phaser/dist/phaser.js:213:33)
    at InputPlugin.shutdown (webpack-internal:///./node_modules/phaser/dist/phaser.js:107171:27)
    at EventEmitter.emit (webpack-internal:///./node_modules/phaser/dist/phaser.js:215:33)
    at Systems.shutdown (webpack-internal:///./node_modules/phaser/dist/phaser.js:201414:16)
    at SceneManager.stop (webpack-internal:///./node_modules/phaser/dist/phaser.js:198962:23)
    at SceneManager.processQueue (webpack-internal:///./node_modules/phaser/dist/phaser.js:197975:27)
    at SceneManager.update (webpack-internal:///./node_modules/phaser/dist/phaser.js:198219:14)
    at Game.step (webpack-internal:///./node_modules/phaser/dist/phaser.js:17199:20)
```

This adds a simple `if` around the call to `removeAllListeners` to make sure it's not falsy.
