### PR TITLE
Docs/v4.0.0/Arcade Typescript

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -946,7 +946,6 @@ var World = new Class({
         this._elapsed += delta;
 
         //  Update all active bodies
-        var body;
         var bodies = this.bodies;
 
         //  Will a step happen this frame?

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1972,8 +1972,8 @@ var World = new Class({
      * @method Phaser.Physics.Arcade.World#canCollide
      * @since 3.70.0
      *
-     * @param {Phaser.Types.Physics.Arcade.ArcadeCollider} body1 - The first body to check.
-     * @param {Phaser.Types.Physics.Arcade.ArcadeCollider} body2 - The second body to check.
+     * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} body1 - The first body to check.
+     * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} body2 - The second body to check.
      *
      * @return {boolean} True if the two bodies will collide, otherwise false.
      */

--- a/src/physics/arcade/typedefs/ArcadeCollider.js
+++ b/src/physics/arcade/typedefs/ArcadeCollider.js
@@ -1,6 +1,0 @@
-/**
- * An Arcade Physics Collider Type.
- *
- * @typedef {(Phaser.Physics.Arcade.Sprite|Phaser.Physics.Arcade.Image|Phaser.Physics.Arcade.StaticGroup|Phaser.Physics.Arcade.Group|Phaser.Tilemaps.TilemapLayer)} Phaser.Types.Physics.Arcade.ArcadeCollider
- * @since 3.70.0
- */

--- a/src/physics/arcade/typedefs/ArcadeColliderType.js
+++ b/src/physics/arcade/typedefs/ArcadeColliderType.js
@@ -1,6 +1,6 @@
 /**
  * An Arcade Physics Collider Type.
  *
- * @typedef {(Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody|Phaser.GameObjects.GameObject|Phaser.GameObjects.Group|Phaser.Physics.Arcade.Sprite|Phaser.Physics.Arcade.Image|Phaser.Physics.Arcade.StaticGroup|Phaser.Physics.Arcade.Group|Phaser.Tilemaps.TilemapLayer|Phaser.Physics.Arcade.Body[]|Phaser.GameObjects.GameObject[]|Phaser.Physics.Arcade.Sprite[]|Phaser.Physics.Arcade.Image[]|Phaser.Physics.Arcade.StaticGroup[]|Phaser.Physics.Arcade.Group[]|Phaser.Tilemaps.TilemapLayer[])} Phaser.Types.Physics.Arcade.ArcadeColliderType
+ * @typedef {(Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody|Phaser.Types.Physics.Arcade.GameObjectWithBody|Phaser.GameObjects.Group|Phaser.Physics.Arcade.Sprite|Phaser.Physics.Arcade.Image|Phaser.Physics.Arcade.StaticGroup|Phaser.Physics.Arcade.Group|Phaser.Tilemaps.TilemapLayer|Phaser.Physics.Arcade.Body[]|Phaser.Types.Physics.Arcade.GameObjectWithBody[]|Phaser.Physics.Arcade.Sprite[]|Phaser.Physics.Arcade.Image[]|Phaser.Physics.Arcade.StaticGroup[]|Phaser.Physics.Arcade.Group[]|Phaser.Tilemaps.TilemapLayer[])} Phaser.Types.Physics.Arcade.ArcadeColliderType
  * @since 3.0.0
  */


### PR DESCRIPTION
This PR

* Updates the Documentation
* Fixes a bug(?)

Describe the changes below:

Delete ArcadeCollider.js (duplicate type) and some other fixes, but would appreciate guidance on the following question before leaving draft mode:

Should it be allowed to pass just a `GameObject` into the collider? Shouldn't it be `GameObjectWithBody`? Without a body GameObject ends up being passed to the collider ok, but I believe it will never collide, and just silently dead end... for example if one GameObject has a body but the other does not, it will just dead end in this block: https://github.com/phaserjs/phaser/blob/v4.0.0/src/physics/arcade/World.js#L1921-L1935

This might be ok, but also I would think it could also be thought of as a bug... and something the type checker should prevent, because why are you passing a gameobject into a collider without a body? Asking this as a discussion though because a). I may have missed something and b). it also might be better to keep this API how it is and simply emit a warning in this case instead of changing the API/type def. I have changed it here so you can see the diff, but if I'm wrong about this happy to defer. It just seems to me not warning the user that their gameobjects are missing bodies could in this case lead to poor devx...

