### PR TITLE
add phaser.d.ts return description to function definitions

### DIFF
--- a/scripts/tsgen/src/Parser.ts
+++ b/scripts/tsgen/src/Parser.ts
@@ -445,6 +445,9 @@ export class Parser {
         let obj = dom.create.function(doclet.name, null, returnType);
         this.setParams(doclet, obj);
 
+        if (doclet.returns?.length)
+            obj.jsDocComment += `\n@returns ${doclet.returns[0].description}`
+
         this.processGeneric(doclet, obj, obj.parameters);
 
         this.processFlags(doclet, obj);


### PR DESCRIPTION
Resolves https://github.com/phaserjs/phaser/issues/7073

Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug (#7073 )

Describe the changes below:

Adds return descriptions to function definitions in `phaser.d.ts`

```
/**
 * Takes an array of Game Objects and aligns them next to each other.
 * 
 * The alignment position is controlled by the `position` parameter, which should be one
 * of the Phaser.Display.Align constants, such as `Phaser.Display.Align.TOP_LEFT`,
 * `Phaser.Display.Align.TOP_CENTER`, etc.
 * 
 * The first item isn't moved. The second item is aligned next to the first,
 * then the third next to the second, and so on.
 * @param items The array of items to be updated by this action.
 * @param position The position to align the items with. This is an align constant, such as `Phaser.Display.Align.LEFT_CENTER`.
 * @param offsetX Optional horizontal offset from the position. Default 0.
 * @param offsetY Optional vertical offset from the position. Default 0.
 * @returns The array of objects that were passed to this Action.
 */
function AlignTo<G extends Phaser.GameObjects.GameObject[]>(items: G, position: number, offsetX?: number, offsetY?: number): G;
```


