### PR TITLE
Updated type of param in MatterPhysics.collision.collides to support null.

### DIFF
--- a/types/matter.d.ts
+++ b/types/matter.d.ts
@@ -5251,10 +5251,10 @@ declare namespace MatterJS {
          * @method collides
          * @param {BodyType} bodyA
          * @param {BodyType} bodyB
-         * @param {Pairs} [pairs] Optionally reuse collision records from existing pairs.
+         * @param {Pairs | null} [pairs] Optionally reuse collision records from existing pairs, pass null to create new records.
          * @return {collision|null} A collision record if detected, otherwise null
          */
-        collides (bodyA: BodyType, bodyB: BodyType, pairs: Pairs): any;
+        collides (bodyA: BodyType, bodyB: BodyType, pairs: Pairs | null): any;
 
     }
 }


### PR DESCRIPTION
**Nullable parameter type bugfix**

The Matter.collision.collides method accepts an optional third parameter to reuse existing collision pairs and reduce GC overhead.
Passing `null` to this method forces new collision pairs to be created and is supported per the Matter.js docs:
* https://brm.io/matter-js/docs/classes/Collision.html#method_collides

This change allows `null` to be passed here without a cumbersome cast eg. `null as any`.