### PR TITLE
Update types of various constants to match their runtime values

### DIFF
--- a/src/animations/events/ADD_ANIMATION_EVENT.js
+++ b/src/animations/events/ADD_ANIMATION_EVENT.js
@@ -13,7 +13,7 @@
  * or the Animation Manager creating a new animation directly.
  *
  * @event Phaser.Animations.Events#ADD_ANIMATION
- * @type {string}
+ * @type {'add'}
  * @since 3.0.0
  *
  * @param {string} key - The key of the Animation that was added to the global Animation Manager.

--- a/src/animations/events/ANIMATION_COMPLETE_EVENT.js
+++ b/src/animations/events/ANIMATION_COMPLETE_EVENT.js
@@ -30,7 +30,7 @@
  * If the animation is restarted while it is already playing, `ANIMATION_RESTART` is emitted.
  *
  * @event Phaser.Animations.Events#ANIMATION_COMPLETE
- * @type {string}
+ * @type {'animationcomplete'}
  * @since 3.50.0
  *
  * @param {Phaser.Animations.Animation} animation - A reference to the Animation that completed.

--- a/src/animations/events/ANIMATION_REPEAT_EVENT.js
+++ b/src/animations/events/ANIMATION_REPEAT_EVENT.js
@@ -27,7 +27,7 @@
  * If the animation is restarted while it is already playing, `ANIMATION_RESTART` is emitted.
  *
  * @event Phaser.Animations.Events#ANIMATION_REPEAT
- * @type {string}
+ * @type {'animationrepeat'}
  * @since 3.50.0
  *
  * @param {Phaser.Animations.Animation} animation - A reference to the Animation that has repeated.

--- a/src/animations/events/ANIMATION_RESTART_EVENT.js
+++ b/src/animations/events/ANIMATION_RESTART_EVENT.js
@@ -25,7 +25,7 @@
  * If the animation is restarted while it is already playing, `ANIMATION_RESTART` is emitted.
  *
  * @event Phaser.Animations.Events#ANIMATION_RESTART
- * @type {string}
+ * @type {'animationrestart'}
  * @since 3.50.0
  *
  * @param {Phaser.Animations.Animation} animation - A reference to the Animation that has restarted.

--- a/src/animations/events/ANIMATION_START_EVENT.js
+++ b/src/animations/events/ANIMATION_START_EVENT.js
@@ -26,7 +26,7 @@
  * If the animation is restarted while it is already playing, `ANIMATION_RESTART` is emitted.
  *
  * @event Phaser.Animations.Events#ANIMATION_START
- * @type {string}
+ * @type {'animationstart'}
  * @since 3.50.0
  *
  * @param {Phaser.Animations.Animation} animation - A reference to the Animation that has started.

--- a/src/animations/events/ANIMATION_STOP_EVENT.js
+++ b/src/animations/events/ANIMATION_STOP_EVENT.js
@@ -26,7 +26,7 @@
  * If the animation is restarted while it is already playing, `ANIMATION_RESTART` is emitted.
  *
  * @event Phaser.Animations.Events#ANIMATION_STOP
- * @type {string}
+ * @type {'animationstop'}
  * @since 3.50.0
  *
  * @param {Phaser.Animations.Animation} animation - A reference to the Animation that has stopped.

--- a/src/animations/events/ANIMATION_UPDATE_EVENT.js
+++ b/src/animations/events/ANIMATION_UPDATE_EVENT.js
@@ -30,7 +30,7 @@
  * If the animation is restarted while it is already playing, `ANIMATION_RESTART` is emitted.
  *
  * @event Phaser.Animations.Events#ANIMATION_UPDATE
- * @type {string}
+ * @type {'animationupdate'}
  * @since 3.50.0
  *
  * @param {Phaser.Animations.Animation} animation - A reference to the Animation that has updated.

--- a/src/animations/events/PAUSE_ALL_EVENT.js
+++ b/src/animations/events/PAUSE_ALL_EVENT.js
@@ -13,7 +13,7 @@
  * that the game has paused as well.
  *
  * @event Phaser.Animations.Events#PAUSE_ALL
- * @type {string}
+ * @type {'pauseall'}
  * @since 3.0.0
  */
 module.exports = 'pauseall';

--- a/src/animations/events/REMOVE_ANIMATION_EVENT.js
+++ b/src/animations/events/REMOVE_ANIMATION_EVENT.js
@@ -10,7 +10,7 @@
  * This event is dispatched when an animation is removed from the global Animation Manager.
  *
  * @event Phaser.Animations.Events#REMOVE_ANIMATION
- * @type {string}
+ * @type {'remove'}
  * @since 3.0.0
  *
  * @param {string} key - The key of the Animation that was removed from the global Animation Manager.

--- a/src/animations/events/RESUME_ALL_EVENT.js
+++ b/src/animations/events/RESUME_ALL_EVENT.js
@@ -12,7 +12,7 @@
  * When this happens all current animations will continue updating again.
  *
  * @event Phaser.Animations.Events#RESUME_ALL
- * @type {string}
+ * @type {'resumeall'}
  * @since 3.0.0
  */
 module.exports = 'resumeall';

--- a/src/cache/events/ADD_EVENT.js
+++ b/src/cache/events/ADD_EVENT.js
@@ -10,7 +10,7 @@
  * This event is dispatched by any Cache that extends the BaseCache each time a new object is added to it.
  *
  * @event Phaser.Cache.Events#ADD
- * @type {string}
+ * @type {'add'}
  * @since 3.0.0
  *
  * @param {Phaser.Cache.BaseCache} cache - The cache to which the object was added.

--- a/src/cache/events/REMOVE_EVENT.js
+++ b/src/cache/events/REMOVE_EVENT.js
@@ -10,7 +10,7 @@
  * This event is dispatched by any Cache that extends the BaseCache each time an object is removed from it.
  *
  * @event Phaser.Cache.Events#REMOVE
- * @type {string}
+ * @type {'remove'}
  * @since 3.0.0
  *
  * @param {Phaser.Cache.BaseCache} cache - The cache from which the object was removed.

--- a/src/cameras/2d/events/DESTROY_EVENT.js
+++ b/src/cameras/2d/events/DESTROY_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#DESTROY
- * @type {string}
+ * @type {'cameradestroy'}
  * @since 3.0.0
  *
  * @param {Phaser.Cameras.Scene2D.BaseCamera} camera - The camera that was destroyed.

--- a/src/cameras/2d/events/FADE_IN_COMPLETE_EVENT.js
+++ b/src/cameras/2d/events/FADE_IN_COMPLETE_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Camera instance using `Camera.on('camerafadeincomplete', listener)`.
  *
  * @event Phaser.Cameras.Scene2D.Events#FADE_IN_COMPLETE
- * @type {string}
+ * @type {'camerafadeincomplete'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/FADE_IN_START_EVENT.js
+++ b/src/cameras/2d/events/FADE_IN_START_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Camera instance using `Camera.on('camerafadeinstart', listener)`.
  *
  * @event Phaser.Cameras.Scene2D.Events#FADE_IN_START
- * @type {string}
+ * @type {'camerafadeinstart'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/FADE_OUT_COMPLETE_EVENT.js
+++ b/src/cameras/2d/events/FADE_OUT_COMPLETE_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Camera instance using `Camera.on('camerafadeoutcomplete', listener)`.
  *
  * @event Phaser.Cameras.Scene2D.Events#FADE_OUT_COMPLETE
- * @type {string}
+ * @type {'camerafadeoutcomplete'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/FADE_OUT_START_EVENT.js
+++ b/src/cameras/2d/events/FADE_OUT_START_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Camera instance using `Camera.on('camerafadeoutstart', listener)`.
  *
  * @event Phaser.Cameras.Scene2D.Events#FADE_OUT_START
- * @type {string}
+ * @type {'camerafadeoutstart'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/FLASH_COMPLETE_EVENT.js
+++ b/src/cameras/2d/events/FLASH_COMPLETE_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#FLASH_COMPLETE
- * @type {string}
+ * @type {'cameraflashcomplete'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/FLASH_START_EVENT.js
+++ b/src/cameras/2d/events/FLASH_START_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#FLASH_START
- * @type {string}
+ * @type {'cameraflashstart'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/FOLLOW_UPDATE_EVENT.js
+++ b/src/cameras/2d/events/FOLLOW_UPDATE_EVENT.js
@@ -14,7 +14,7 @@
  * Listen to it from a Camera instance using: `camera.on('followupdate', listener)`.
  *
  * @event Phaser.Cameras.Scene2D.Events#FOLLOW_UPDATE
- * @type {string}
+ * @type {'followupdate'}
  * @since 3.50.0
  *
  * @param {Phaser.Cameras.Scene2D.BaseCamera} camera - The camera that emitted the event.

--- a/src/cameras/2d/events/PAN_COMPLETE_EVENT.js
+++ b/src/cameras/2d/events/PAN_COMPLETE_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#PAN_COMPLETE
- * @type {string}
+ * @type {'camerapancomplete'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/PAN_START_EVENT.js
+++ b/src/cameras/2d/events/PAN_START_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#PAN_START
- * @type {string}
+ * @type {'camerapanstart'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/POST_RENDER_EVENT.js
+++ b/src/cameras/2d/events/POST_RENDER_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Camera instance using: `camera.on('postrender', listener)`.
  *
  * @event Phaser.Cameras.Scene2D.Events#POST_RENDER
- * @type {string}
+ * @type {'postrender'}
  * @since 3.0.0
  *
  * @param {Phaser.Cameras.Scene2D.BaseCamera} camera - The camera that has finished rendering to a texture.

--- a/src/cameras/2d/events/PRE_RENDER_EVENT.js
+++ b/src/cameras/2d/events/PRE_RENDER_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Camera instance using: `camera.on('prerender', listener)`.
  *
  * @event Phaser.Cameras.Scene2D.Events#PRE_RENDER
- * @type {string}
+ * @type {'prerender'}
  * @since 3.0.0
  *
  * @param {Phaser.Cameras.Scene2D.BaseCamera} camera - The camera that is about to render to a texture.

--- a/src/cameras/2d/events/ROTATE_COMPLETE_EVENT.js
+++ b/src/cameras/2d/events/ROTATE_COMPLETE_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#ROTATE_COMPLETE
- * @type {string}
+ * @type {'camerarotatecomplete'}
  * @since 3.23.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/ROTATE_START_EVENT.js
+++ b/src/cameras/2d/events/ROTATE_START_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#ROTATE_START
- * @type {string}
+ * @type {'camerarotatestart'}
  * @since 3.23.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/SHAKE_COMPLETE_EVENT.js
+++ b/src/cameras/2d/events/SHAKE_COMPLETE_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#SHAKE_COMPLETE
- * @type {string}
+ * @type {'camerashakecomplete'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/SHAKE_START_EVENT.js
+++ b/src/cameras/2d/events/SHAKE_START_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#SHAKE_START
- * @type {string}
+ * @type {'camerashakestart'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/ZOOM_COMPLETE_EVENT.js
+++ b/src/cameras/2d/events/ZOOM_COMPLETE_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#ZOOM_COMPLETE
- * @type {string}
+ * @type {'camerazoomcomplete'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/cameras/2d/events/ZOOM_START_EVENT.js
+++ b/src/cameras/2d/events/ZOOM_START_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Cameras.Scene2D.Events#ZOOM_START
- * @type {string}
+ * @type {'camerazoomstart'}
  * @since 3.3.0
  *
  * @param {Phaser.Cameras.Scene2D.Camera} camera - The camera that the effect began on.

--- a/src/core/events/BLUR_EVENT.js
+++ b/src/core/events/BLUR_EVENT.js
@@ -12,7 +12,7 @@
  * tab, or if they simply remove focus from the browser to another app.
  *
  * @event Phaser.Core.Events#BLUR
- * @type {string}
+ * @type {'blur'}
  * @since 3.0.0
  */
 module.exports = 'blur';

--- a/src/core/events/BOOT_EVENT.js
+++ b/src/core/events/BOOT_EVENT.js
@@ -11,7 +11,7 @@
  * The global systems use this event to know when to set themselves up, dispatching their own `ready` events as required.
  *
  * @event Phaser.Core.Events#BOOT
- * @type {string}
+ * @type {'boot'}
  * @since 3.0.0
  */
 module.exports = 'boot';

--- a/src/core/events/CONTEXT_LOST_EVENT.js
+++ b/src/core/events/CONTEXT_LOST_EVENT.js
@@ -12,7 +12,7 @@
  * The renderer halts all rendering and cannot resume after this happens.
  *
  * @event Phaser.Core.Events#CONTEXT_LOST
- * @type {string}
+ * @type {'contextlost'}
  * @since 3.19.0
  */
 module.exports = 'contextlost';

--- a/src/core/events/DESTROY_EVENT.js
+++ b/src/core/events/DESTROY_EVENT.js
@@ -12,7 +12,7 @@
  * Custom plugins and game code should also do the same.
  *
  * @event Phaser.Core.Events#DESTROY
- * @type {string}
+ * @type {'destroy'}
  * @since 3.0.0
  */
 module.exports = 'destroy';

--- a/src/core/events/FOCUS_EVENT.js
+++ b/src/core/events/FOCUS_EVENT.js
@@ -11,7 +11,7 @@
  * enters a focused state. The focus event is raised when the window re-gains focus, having previously lost it.
  *
  * @event Phaser.Core.Events#FOCUS
- * @type {string}
+ * @type {'focus'}
  * @since 3.0.0
  */
 module.exports = 'focus';

--- a/src/core/events/HIDDEN_EVENT.js
+++ b/src/core/events/HIDDEN_EVENT.js
@@ -15,7 +15,7 @@
  * your game should account for in its own code, should the pause be an issue (i.e. for multiplayer games)
  *
  * @event Phaser.Core.Events#HIDDEN
- * @type {string}
+ * @type {'hidden'}
  * @since 3.0.0
  */
 module.exports = 'hidden';

--- a/src/core/events/PAUSE_EVENT.js
+++ b/src/core/events/PAUSE_EVENT.js
@@ -10,7 +10,7 @@
  * This event is dispatched when the Game loop enters a paused state, usually as a result of the Visibility Handler.
  *
  * @event Phaser.Core.Events#PAUSE
- * @type {string}
+ * @type {'pause'}
  * @since 3.0.0
  */
 module.exports = 'pause';

--- a/src/core/events/POST_RENDER_EVENT.js
+++ b/src/core/events/POST_RENDER_EVENT.js
@@ -13,7 +13,7 @@
  * Use it for any last minute post-processing before the next game step begins.
  *
  * @event Phaser.Core.Events#POST_RENDER
- * @type {string}
+ * @type {'postrender'}
  * @since 3.0.0
  *
  * @param {(Phaser.Renderer.Canvas.CanvasRenderer|Phaser.Renderer.WebGL.WebGLRenderer)} renderer - A reference to the current renderer being used by the Game instance.

--- a/src/core/events/POST_STEP_EVENT.js
+++ b/src/core/events/POST_STEP_EVENT.js
@@ -11,7 +11,7 @@
  * Hook into it from plugins or systems that need to do things before the render starts.
  *
  * @event Phaser.Core.Events#POST_STEP
- * @type {string}
+ * @type {'poststep'}
  * @since 3.0.0
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/core/events/PRE_RENDER_EVENT.js
+++ b/src/core/events/PRE_RENDER_EVENT.js
@@ -12,7 +12,7 @@
  * The renderer will already have been initialized this frame, clearing itself and preparing to receive the Scenes for rendering, but it won't have actually drawn anything yet.
  *
  * @event Phaser.Core.Events#PRE_RENDER
- * @type {string}
+ * @type {'prerender'}
  * @since 3.0.0
  *
  * @param {(Phaser.Renderer.Canvas.CanvasRenderer|Phaser.Renderer.WebGL.WebGLRenderer)} renderer - A reference to the current renderer being used by the Game instance.

--- a/src/core/events/PRE_STEP_EVENT.js
+++ b/src/core/events/PRE_STEP_EVENT.js
@@ -11,7 +11,7 @@
  * Hook into it from plugins or systems that need to update before the Scene Manager does.
  *
  * @event Phaser.Core.Events#PRE_STEP
- * @type {string}
+ * @type {'prestep'}
  * @since 3.0.0
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/core/events/READY_EVENT.js
+++ b/src/core/events/READY_EVENT.js
@@ -11,7 +11,7 @@
  * and all local systems are now able to start.
  *
  * @event Phaser.Core.Events#READY
- * @type {string}
+ * @type {'ready'}
  * @since 3.0.0
  */
 module.exports = 'ready';

--- a/src/core/events/RESUME_EVENT.js
+++ b/src/core/events/RESUME_EVENT.js
@@ -10,7 +10,7 @@
  * This event is dispatched when the game loop leaves a paused state and resumes running.
  *
  * @event Phaser.Core.Events#RESUME
- * @type {string}
+ * @type {'resume'}
  * @since 3.0.0
  *
  * @param {number} pauseDuration - The duration, in ms, that the game was paused for, or 0 if {@link Phaser.Game#resume} was called.

--- a/src/core/events/STEP_EVENT.js
+++ b/src/core/events/STEP_EVENT.js
@@ -11,7 +11,7 @@
  * Hook into it from plugins or systems that need to update before the Scene Manager does, but after the core Systems have.
  *
  * @event Phaser.Core.Events#STEP
- * @type {string}
+ * @type {'step'}
  * @since 3.0.0
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/core/events/SYSTEM_READY_EVENT.js
+++ b/src/core/events/SYSTEM_READY_EVENT.js
@@ -11,7 +11,7 @@
  * This event is dispatched just once by the Game instance.
  *
  * @event Phaser.Core.Events#SYSTEM_READY
- * @type {string}
+ * @type {'systemready'}
  * @since 3.70.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/core/events/VISIBLE_EVENT.js
+++ b/src/core/events/VISIBLE_EVENT.js
@@ -13,7 +13,7 @@
  * Only browsers that support the Visibility API will cause this event to be emitted.
  *
  * @event Phaser.Core.Events#VISIBLE
- * @type {string}
+ * @type {'visible'}
  * @since 3.0.0
  */
 module.exports = 'visible';

--- a/src/data/events/CHANGE_DATA_EVENT.js
+++ b/src/data/events/CHANGE_DATA_EVENT.js
@@ -16,7 +16,7 @@
  * To listen for the change of a specific item, use the `CHANGE_DATA_KEY_EVENT` event.
  *
  * @event Phaser.Data.Events#CHANGE_DATA
- * @type {string}
+ * @type {'changedata'}
  * @since 3.0.0
  *
  * @param {any} parent - A reference to the object that the Data Manager responsible for this event belongs to.

--- a/src/data/events/DESTROY_EVENT.js
+++ b/src/data/events/DESTROY_EVENT.js
@@ -10,7 +10,7 @@
  * The Data Manager will listen for the destroy event from its parent, and then close itself down.
  *
  * @event Phaser.Data.Events#DESTROY
- * @type {string}
+ * @type {'destroy'}
  * @since 3.50.0
  */
 module.exports = 'destroy';

--- a/src/data/events/REMOVE_DATA_EVENT.js
+++ b/src/data/events/REMOVE_DATA_EVENT.js
@@ -13,7 +13,7 @@
  * the removal of a data item on a Game Object you would use: `sprite.on('removedata', listener)`.
  *
  * @event Phaser.Data.Events#REMOVE_DATA
- * @type {string}
+ * @type {'removedata'}
  * @since 3.0.0
  *
  * @param {any} parent - A reference to the object that owns the instance of the Data Manager responsible for this event.

--- a/src/data/events/SET_DATA_EVENT.js
+++ b/src/data/events/SET_DATA_EVENT.js
@@ -13,7 +13,7 @@
  * the addition of a new data item on a Game Object you would use: `sprite.on('setdata', listener)`.
  *
  * @event Phaser.Data.Events#SET_DATA
- * @type {string}
+ * @type {'setdata'}
  * @since 3.0.0
  *
  * @param {any} parent - A reference to the object that owns the instance of the Data Manager responsible for this event.

--- a/src/gameobjects/events/ADDED_TO_SCENE_EVENT.js
+++ b/src/gameobjects/events/ADDED_TO_SCENE_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it on a Game Object instance using `GameObject.on('addedtoscene', listener)`.
  *
  * @event Phaser.GameObjects.Events#ADDED_TO_SCENE
- * @type {string}
+ * @type {'addedtoscene'}
  * @since 3.50.0
  *
  * @param {Phaser.GameObjects.GameObject} gameObject - The Game Object that was added to the Scene.

--- a/src/gameobjects/events/DESTROY_EVENT.js
+++ b/src/gameobjects/events/DESTROY_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it on a Game Object instance using `GameObject.on('destroy', listener)`.
  *
  * @event Phaser.GameObjects.Events#DESTROY
- * @type {string}
+ * @type {'destroy'}
  * @since 3.0.0
  *
  * @param {Phaser.GameObjects.GameObject} gameObject - The Game Object which is being destroyed.

--- a/src/gameobjects/events/REMOVED_FROM_SCENE_EVENT.js
+++ b/src/gameobjects/events/REMOVED_FROM_SCENE_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it on a Game Object instance using `GameObject.on('removedfromscene', listener)`.
  *
  * @event Phaser.GameObjects.Events#REMOVED_FROM_SCENE
- * @type {string}
+ * @type {'removedfromscene'}
  * @since 3.50.0
  *
  * @param {Phaser.GameObjects.GameObject} gameObject - The Game Object that was removed from the Scene.

--- a/src/gameobjects/events/VIDEO_COMPLETE_EVENT.js
+++ b/src/gameobjects/events/VIDEO_COMPLETE_EVENT.js
@@ -19,7 +19,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('complete', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_COMPLETE
- * @type {string}
+ * @type {'complete'}
  * @since 3.20.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which completed playback.

--- a/src/gameobjects/events/VIDEO_CREATED_EVENT.js
+++ b/src/gameobjects/events/VIDEO_CREATED_EVENT.js
@@ -14,7 +14,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('created', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_CREATED
- * @type {string}
+ * @type {'created'}
  * @since 3.20.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which raised the event.

--- a/src/gameobjects/events/VIDEO_ERROR_EVENT.js
+++ b/src/gameobjects/events/VIDEO_ERROR_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('error', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_ERROR
- * @type {string}
+ * @type {'error'}
  * @since 3.20.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which threw the error.

--- a/src/gameobjects/events/VIDEO_LOCKED_EVENT.js
+++ b/src/gameobjects/events/VIDEO_LOCKED_EVENT.js
@@ -17,7 +17,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('locked', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_LOCKED
- * @type {string}
+ * @type {'locked'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which raised the event.

--- a/src/gameobjects/events/VIDEO_LOOP_EVENT.js
+++ b/src/gameobjects/events/VIDEO_LOOP_EVENT.js
@@ -19,7 +19,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('loop', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_LOOP
- * @type {string}
+ * @type {'loop'}
  * @since 3.20.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which has looped.

--- a/src/gameobjects/events/VIDEO_METADATA_EVENT.js
+++ b/src/gameobjects/events/VIDEO_METADATA_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('metadata', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_METADATA
- * @type {string}
+ * @type {'metadata'}
  * @since 3.80.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which fired the event.

--- a/src/gameobjects/events/VIDEO_PLAYING_EVENT.js
+++ b/src/gameobjects/events/VIDEO_PLAYING_EVENT.js
@@ -14,7 +14,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('playing', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_PLAYING
- * @type {string}
+ * @type {'playing'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which started playback.

--- a/src/gameobjects/events/VIDEO_PLAY_EVENT.js
+++ b/src/gameobjects/events/VIDEO_PLAY_EVENT.js
@@ -15,7 +15,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('play', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_PLAY
- * @type {string}
+ * @type {'play'}
  * @since 3.20.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which started playback.

--- a/src/gameobjects/events/VIDEO_SEEKED_EVENT.js
+++ b/src/gameobjects/events/VIDEO_SEEKED_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('seeked', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_SEEKED
- * @type {string}
+ * @type {'seeked'}
  * @since 3.20.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which completed seeking.

--- a/src/gameobjects/events/VIDEO_SEEKING_EVENT.js
+++ b/src/gameobjects/events/VIDEO_SEEKING_EVENT.js
@@ -13,7 +13,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('seeking', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_SEEKING
- * @type {string}
+ * @type {'seeking'}
  * @since 3.20.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which started seeking.

--- a/src/gameobjects/events/VIDEO_STALLED_EVENT.js
+++ b/src/gameobjects/events/VIDEO_STALLED_EVENT.js
@@ -24,7 +24,7 @@
  * the current batch of frames have rendered.
  *
  * @event Phaser.GameObjects.Events#VIDEO_STALLED
- * @type {string}
+ * @type {'stalled'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which threw the error.

--- a/src/gameobjects/events/VIDEO_STOP_EVENT.js
+++ b/src/gameobjects/events/VIDEO_STOP_EVENT.js
@@ -13,7 +13,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('stop', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_STOP
- * @type {string}
+ * @type {'stop'}
  * @since 3.20.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which stopped playback.

--- a/src/gameobjects/events/VIDEO_TEXTURE_EVENT.js
+++ b/src/gameobjects/events/VIDEO_TEXTURE_EVENT.js
@@ -17,7 +17,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('textureready', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_TEXTURE
- * @type {string}
+ * @type {'textureready'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object that emitted the event.

--- a/src/gameobjects/events/VIDEO_UNLOCKED_EVENT.js
+++ b/src/gameobjects/events/VIDEO_UNLOCKED_EVENT.js
@@ -13,7 +13,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('unlocked', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_UNLOCKED
- * @type {string}
+ * @type {'unlocked'}
  * @since 3.20.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which raised the event.

--- a/src/gameobjects/events/VIDEO_UNSUPPORTED_EVENT.js
+++ b/src/gameobjects/events/VIDEO_UNSUPPORTED_EVENT.js
@@ -14,7 +14,7 @@
  * Listen for it from a Video Game Object instance using `Video.on('unsupported', listener)`.
  *
  * @event Phaser.GameObjects.Events#VIDEO_UNSUPPORTED
- * @type {string}
+ * @type {'unsupported'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Video} video - The Video Game Object which started playback.

--- a/src/gameobjects/particles/events/COMPLETE_EVENT.js
+++ b/src/gameobjects/particles/events/COMPLETE_EVENT.js
@@ -14,7 +14,7 @@
  * Listen for it on a Particle Emitter instance using `ParticleEmitter.on('complete', listener)`.
  *
  * @event Phaser.GameObjects.Particles.Events#COMPLETE
- * @type {string}
+ * @type {'complete'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Particles.ParticleEmitter} emitter - A reference to the Particle Emitter that just completed.

--- a/src/gameobjects/particles/events/DEATH_ZONE_EVENT.js
+++ b/src/gameobjects/particles/events/DEATH_ZONE_EVENT.js
@@ -14,7 +14,7 @@
  * If you wish to know when the final particle is killed, see the `COMPLETE` event.
  *
  * @event Phaser.GameObjects.Particles.Events#DEATH_ZONE
- * @type {string}
+ * @type {'deathzone'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Particles.ParticleEmitter} emitter - A reference to the Particle Emitter that owns the Particle and Death Zone.

--- a/src/gameobjects/particles/events/EXPLODE_EVENT.js
+++ b/src/gameobjects/particles/events/EXPLODE_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it on a Particle Emitter instance using `ParticleEmitter.on('explode', listener)`.
  *
  * @event Phaser.GameObjects.Particles.Events#EXPLODE
- * @type {string}
+ * @type {'explode'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Particles.ParticleEmitter} emitter - A reference to the Particle Emitter that just completed.

--- a/src/gameobjects/particles/events/START_EVENT.js
+++ b/src/gameobjects/particles/events/START_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it on a Particle Emitter instance using `ParticleEmitter.on('start', listener)`.
  *
  * @event Phaser.GameObjects.Particles.Events#START
- * @type {string}
+ * @type {'start'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Particles.ParticleEmitter} emitter - A reference to the Particle Emitter that just completed.

--- a/src/gameobjects/particles/events/STOP_EVENT.js
+++ b/src/gameobjects/particles/events/STOP_EVENT.js
@@ -20,7 +20,7 @@
  * If you wish to know when the final particle is killed, see the `COMPLETE` event.
  *
  * @event Phaser.GameObjects.Particles.Events#STOP
- * @type {string}
+ * @type {'stop'}
  * @since 3.60.0
  *
  * @param {Phaser.GameObjects.Particles.ParticleEmitter} emitter - A reference to the Particle Emitter that just completed.

--- a/src/input/events/BOOT_EVENT.js
+++ b/src/input/events/BOOT_EVENT.js
@@ -10,7 +10,7 @@
  * This internal event is dispatched by the Input Plugin when it boots, signalling to all of its systems to create themselves.
  *
  * @event Phaser.Input.Events#BOOT
- * @type {string}
+ * @type {'boot'}
  * @since 3.0.0
  */
 module.exports = 'boot';

--- a/src/input/events/DESTROY_EVENT.js
+++ b/src/input/events/DESTROY_EVENT.js
@@ -10,7 +10,7 @@
  * This internal event is dispatched by the Input Plugin when it is destroyed, signalling to all of its systems to destroy themselves.
  *
  * @event Phaser.Input.Events#DESTROY
- * @type {string}
+ * @type {'destroy'}
  * @since 3.0.0
  */
 module.exports = 'destroy';

--- a/src/input/events/DRAG_END_EVENT.js
+++ b/src/input/events/DRAG_END_EVENT.js
@@ -14,7 +14,7 @@
  * To listen for this event from a _specific_ Game Object, use the [GAMEOBJECT_DRAG_END]{@linkcode Phaser.Input.Events#event:GAMEOBJECT_DRAG_END} event instead.
  *
  * @event Phaser.Input.Events#DRAG_END
- * @type {string}
+ * @type {'dragend'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/DRAG_ENTER_EVENT.js
+++ b/src/input/events/DRAG_ENTER_EVENT.js
@@ -16,7 +16,7 @@
  * To listen for this event from a _specific_ Game Object, use the [GAMEOBJECT_DRAG_ENTER]{@linkcode Phaser.Input.Events#event:GAMEOBJECT_DRAG_ENTER} event instead.
  *
  * @event Phaser.Input.Events#DRAG_ENTER
- * @type {string}
+ * @type {'dragenter'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/DRAG_EVENT.js
+++ b/src/input/events/DRAG_EVENT.js
@@ -16,7 +16,7 @@
  * To listen for this event from a _specific_ Game Object, use the [GAMEOBJECT_DRAG]{@linkcode Phaser.Input.Events#event:GAMEOBJECT_DRAG} event instead.
  *
  * @event Phaser.Input.Events#DRAG
- * @type {string}
+ * @type {'drag'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/DRAG_LEAVE_EVENT.js
+++ b/src/input/events/DRAG_LEAVE_EVENT.js
@@ -16,7 +16,7 @@
  * To listen for this event from a _specific_ Game Object, use the [GAMEOBJECT_DRAG_LEAVE]{@linkcode Phaser.Input.Events#event:GAMEOBJECT_DRAG_LEAVE} event instead.
  *
  * @event Phaser.Input.Events#DRAG_LEAVE
- * @type {string}
+ * @type {'dragleave'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/DRAG_OVER_EVENT.js
+++ b/src/input/events/DRAG_OVER_EVENT.js
@@ -19,7 +19,7 @@
  * To listen for this event from a _specific_ Game Object, use the [GAMEOBJECT_DRAG_OVER]{@linkcode Phaser.Input.Events#event:GAMEOBJECT_DRAG_OVER} event instead.
  *
  * @event Phaser.Input.Events#DRAG_OVER
- * @type {string}
+ * @type {'dragover'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/DRAG_START_EVENT.js
+++ b/src/input/events/DRAG_START_EVENT.js
@@ -16,7 +16,7 @@
  * To listen for this event from a _specific_ Game Object, use the [GAMEOBJECT_DRAG_START]{@linkcode Phaser.Input.Events#event:GAMEOBJECT_DRAG_START} event instead.
  *
  * @event Phaser.Input.Events#DRAG_START
- * @type {string}
+ * @type {'dragstart'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/DROP_EVENT.js
+++ b/src/input/events/DROP_EVENT.js
@@ -14,7 +14,7 @@
  * To listen for this event from a _specific_ Game Object, use the [GAMEOBJECT_DROP]{@linkcode Phaser.Input.Events#event:GAMEOBJECT_DROP} event instead.
  *
  * @event Phaser.Input.Events#DROP
- * @type {string}
+ * @type {'drop'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_DOWN_EVENT.js
+++ b/src/input/events/GAMEOBJECT_DOWN_EVENT.js
@@ -26,7 +26,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_DOWN
- * @type {string}
+ * @type {'gameobjectdown'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_DRAG_END_EVENT.js
+++ b/src/input/events/GAMEOBJECT_DRAG_END_EVENT.js
@@ -16,7 +16,7 @@
  * See [GameObject.setInteractive](Phaser.GameObjects.GameObject#setInteractive) for more details.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_DRAG_END
- * @type {string}
+ * @type {'dragend'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_DRAG_ENTER_EVENT.js
+++ b/src/input/events/GAMEOBJECT_DRAG_ENTER_EVENT.js
@@ -16,7 +16,7 @@
  * See [GameObject.setInteractive]{@link Phaser.GameObjects.GameObject#setInteractive} for more details.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_DRAG_ENTER
- * @type {string}
+ * @type {'dragenter'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_DRAG_EVENT.js
+++ b/src/input/events/GAMEOBJECT_DRAG_EVENT.js
@@ -16,7 +16,7 @@
  * See [GameObject.setInteractive]{@link Phaser.GameObjects.GameObject#setInteractive} for more details.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_DRAG
- * @type {string}
+ * @type {'drag'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_DRAG_LEAVE_EVENT.js
+++ b/src/input/events/GAMEOBJECT_DRAG_LEAVE_EVENT.js
@@ -16,7 +16,7 @@
  * See [GameObject.setInteractive]{@link Phaser.GameObjects.GameObject#setInteractive} for more details.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_DRAG_LEAVE
- * @type {string}
+ * @type {'dragleave'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_DRAG_OVER_EVENT.js
+++ b/src/input/events/GAMEOBJECT_DRAG_OVER_EVENT.js
@@ -19,7 +19,7 @@
  * See [GameObject.setInteractive]{@link Phaser.GameObjects.GameObject#setInteractive} for more details.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_DRAG_OVER
- * @type {string}
+ * @type {'dragover'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_DRAG_START_EVENT.js
+++ b/src/input/events/GAMEOBJECT_DRAG_START_EVENT.js
@@ -19,7 +19,7 @@
  * For example, `gameObject.input.dragStartX`, `dragStartY` and so on.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_DRAG_START
- * @type {string}
+ * @type {'dragstart'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_DROP_EVENT.js
+++ b/src/input/events/GAMEOBJECT_DROP_EVENT.js
@@ -16,7 +16,7 @@
  * See [GameObject.setInteractive]{@link Phaser.GameObjects.GameObject#setInteractive} for more details.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_DROP
- * @type {string}
+ * @type {'drop'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_MOVE_EVENT.js
+++ b/src/input/events/GAMEOBJECT_MOVE_EVENT.js
@@ -26,7 +26,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_MOVE
- * @type {string}
+ * @type {'gameobjectmove'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_OUT_EVENT.js
+++ b/src/input/events/GAMEOBJECT_OUT_EVENT.js
@@ -29,7 +29,7 @@
  * please listen for the [GAME_OUT]{@linkcode Phaser.Input.Events#event:GAME_OUT} event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_OUT
- * @type {string}
+ * @type {'gameobjectout'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_OVER_EVENT.js
+++ b/src/input/events/GAMEOBJECT_OVER_EVENT.js
@@ -26,7 +26,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_OVER
- * @type {string}
+ * @type {'gameobjectover'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_POINTER_DOWN_EVENT.js
+++ b/src/input/events/GAMEOBJECT_POINTER_DOWN_EVENT.js
@@ -25,7 +25,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_POINTER_DOWN
- * @type {string}
+ * @type {'pointerdown'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_POINTER_MOVE_EVENT.js
+++ b/src/input/events/GAMEOBJECT_POINTER_MOVE_EVENT.js
@@ -25,7 +25,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_POINTER_MOVE
- * @type {string}
+ * @type {'pointermove'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_POINTER_OUT_EVENT.js
+++ b/src/input/events/GAMEOBJECT_POINTER_OUT_EVENT.js
@@ -28,7 +28,7 @@
  * please listen for the [GAME_OUT]{@linkcode Phaser.Input.Events#event:GAME_OUT} event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_POINTER_OUT
- * @type {string}
+ * @type {'pointerout'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_POINTER_OVER_EVENT.js
+++ b/src/input/events/GAMEOBJECT_POINTER_OVER_EVENT.js
@@ -25,7 +25,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_POINTER_OVER
- * @type {string}
+ * @type {'pointerover'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_POINTER_UP_EVENT.js
+++ b/src/input/events/GAMEOBJECT_POINTER_UP_EVENT.js
@@ -25,7 +25,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_POINTER_UP
- * @type {string}
+ * @type {'pointerup'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_POINTER_WHEEL_EVENT.js
+++ b/src/input/events/GAMEOBJECT_POINTER_WHEEL_EVENT.js
@@ -25,7 +25,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_POINTER_WHEEL
- * @type {string}
+ * @type {'wheel'}
  * @since 3.18.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_UP_EVENT.js
+++ b/src/input/events/GAMEOBJECT_UP_EVENT.js
@@ -26,7 +26,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_UP
- * @type {string}
+ * @type {'gameobjectup'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAMEOBJECT_WHEEL_EVENT.js
+++ b/src/input/events/GAMEOBJECT_WHEEL_EVENT.js
@@ -26,7 +26,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#GAMEOBJECT_WHEEL
- * @type {string}
+ * @type {'gameobjectwheel'}
  * @since 3.18.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/GAME_OUT_EVENT.js
+++ b/src/input/events/GAME_OUT_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to this event from within a Scene using: `this.input.on('gameout', listener)`.
  *
  * @event Phaser.Input.Events#GAME_OUT
- * @type {string}
+ * @type {'gameout'}
  * @since 3.16.1
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/input/events/GAME_OVER_EVENT.js
+++ b/src/input/events/GAME_OVER_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to this event from within a Scene using: `this.input.on('gameover', listener)`.
  *
  * @event Phaser.Input.Events#GAME_OVER
- * @type {string}
+ * @type {'gameover'}
  * @since 3.16.1
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/input/events/MANAGER_BOOT_EVENT.js
+++ b/src/input/events/MANAGER_BOOT_EVENT.js
@@ -10,7 +10,7 @@
  * This internal event is dispatched by the Input Manager when it boots.
  *
  * @event Phaser.Input.Events#MANAGER_BOOT
- * @type {string}
+ * @type {'boot'}
  * @since 3.0.0
  */
 module.exports = 'boot';

--- a/src/input/events/MANAGER_PROCESS_EVENT.js
+++ b/src/input/events/MANAGER_PROCESS_EVENT.js
@@ -11,7 +11,7 @@
  * and it wants the Input Plugins to update themselves.
  *
  * @event Phaser.Input.Events#MANAGER_PROCESS
- * @type {string}
+ * @type {'process'}
  * @since 3.0.0
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/input/events/MANAGER_UPDATE_EVENT.js
+++ b/src/input/events/MANAGER_UPDATE_EVENT.js
@@ -10,7 +10,7 @@
  * This internal event is dispatched by the Input Manager as part of its update step.
  *
  * @event Phaser.Input.Events#MANAGER_UPDATE
- * @type {string}
+ * @type {'update'}
  * @since 3.0.0
  */
 module.exports = 'update';

--- a/src/input/events/POINTERLOCK_CHANGE_EVENT.js
+++ b/src/input/events/POINTERLOCK_CHANGE_EVENT.js
@@ -10,7 +10,7 @@
  * This event is dispatched by the Input Manager when it is processing a native Pointer Lock Change DOM Event.
  *
  * @event Phaser.Input.Events#POINTERLOCK_CHANGE
- * @type {string}
+ * @type {'pointerlockchange'}
  * @since 3.0.0
  *
  * @param {Event} event - The native DOM Event.

--- a/src/input/events/POINTER_DOWN_EVENT.js
+++ b/src/input/events/POINTER_DOWN_EVENT.js
@@ -21,7 +21,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#POINTER_DOWN
- * @type {string}
+ * @type {'pointerdown'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/POINTER_DOWN_OUTSIDE_EVENT.js
+++ b/src/input/events/POINTER_DOWN_OUTSIDE_EVENT.js
@@ -21,7 +21,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#POINTER_DOWN_OUTSIDE
- * @type {string}
+ * @type {'pointerdownoutside'}
  * @since 3.16.1
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/POINTER_MOVE_EVENT.js
+++ b/src/input/events/POINTER_MOVE_EVENT.js
@@ -21,7 +21,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#POINTER_MOVE
- * @type {string}
+ * @type {'pointermove'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/POINTER_OUT_EVENT.js
+++ b/src/input/events/POINTER_OUT_EVENT.js
@@ -24,7 +24,7 @@
  * please listen for the [GAME_OUT]{@linkcode Phaser.Input.Events#event:GAME_OUT} event.
  *
  * @event Phaser.Input.Events#POINTER_OUT
- * @type {string}
+ * @type {'pointerout'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/POINTER_OVER_EVENT.js
+++ b/src/input/events/POINTER_OVER_EVENT.js
@@ -21,7 +21,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#POINTER_OVER
- * @type {string}
+ * @type {'pointerover'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/POINTER_UP_EVENT.js
+++ b/src/input/events/POINTER_UP_EVENT.js
@@ -21,7 +21,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#POINTER_UP
- * @type {string}
+ * @type {'pointerup'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/POINTER_UP_OUTSIDE_EVENT.js
+++ b/src/input/events/POINTER_UP_OUTSIDE_EVENT.js
@@ -21,7 +21,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#POINTER_UP_OUTSIDE
- * @type {string}
+ * @type {'pointerupoutside'}
  * @since 3.16.1
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/POINTER_WHEEL_EVENT.js
+++ b/src/input/events/POINTER_WHEEL_EVENT.js
@@ -21,7 +21,7 @@
  * the propagation of this event.
  *
  * @event Phaser.Input.Events#POINTER_WHEEL
- * @type {string}
+ * @type {'wheel'}
  * @since 3.18.0
  *
  * @param {Phaser.Input.Pointer} pointer - The Pointer responsible for triggering this event.

--- a/src/input/events/PRE_UPDATE_EVENT.js
+++ b/src/input/events/PRE_UPDATE_EVENT.js
@@ -11,7 +11,7 @@
  * This hook is designed specifically for input plugins, but can also be listened to from user-land code.
  *
  * @event Phaser.Input.Events#PRE_UPDATE
- * @type {string}
+ * @type {'preupdate'}
  * @since 3.0.0
  */
 module.exports = 'preupdate';

--- a/src/input/events/SHUTDOWN_EVENT.js
+++ b/src/input/events/SHUTDOWN_EVENT.js
@@ -10,7 +10,7 @@
  * This internal event is dispatched by the Input Plugin when it shuts down, signalling to all of its systems to shut themselves down.
  *
  * @event Phaser.Input.Events#SHUTDOWN
- * @type {string}
+ * @type {'shutdown'}
  * @since 3.0.0
  */
 module.exports = 'shutdown';

--- a/src/input/events/START_EVENT.js
+++ b/src/input/events/START_EVENT.js
@@ -11,7 +11,7 @@
  * signalling to all of its internal systems to start.
  *
  * @event Phaser.Input.Events#START
- * @type {string}
+ * @type {'start'}
  * @since 3.0.0
  */
 module.exports = 'start';

--- a/src/input/events/UPDATE_EVENT.js
+++ b/src/input/events/UPDATE_EVENT.js
@@ -11,7 +11,7 @@
  * This hook is designed specifically for input plugins, but can also be listened to from user-land code.
  *
  * @event Phaser.Input.Events#UPDATE
- * @type {string}
+ * @type {'update'}
  * @since 3.0.0
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/input/gamepad/events/BUTTON_DOWN_EVENT.js
+++ b/src/input/gamepad/events/BUTTON_DOWN_EVENT.js
@@ -14,7 +14,7 @@
  * You can also listen for a DOWN event from a Gamepad instance. See the [GAMEPAD_BUTTON_DOWN]{@linkcode Phaser.Input.Gamepad.Events#event:GAMEPAD_BUTTON_DOWN} event for details.
  *
  * @event Phaser.Input.Gamepad.Events#BUTTON_DOWN
- * @type {string}
+ * @type {'down'}
  * @since 3.10.0
  *
  * @param {Phaser.Input.Gamepad} pad - A reference to the Gamepad on which the button was pressed.

--- a/src/input/gamepad/events/BUTTON_UP_EVENT.js
+++ b/src/input/gamepad/events/BUTTON_UP_EVENT.js
@@ -14,7 +14,7 @@
  * You can also listen for an UP event from a Gamepad instance. See the [GAMEPAD_BUTTON_UP]{@linkcode Phaser.Input.Gamepad.Events#event:GAMEPAD_BUTTON_UP} event for details.
  *
  * @event Phaser.Input.Gamepad.Events#BUTTON_UP
- * @type {string}
+ * @type {'up'}
  * @since 3.10.0
  *
  * @param {Phaser.Input.Gamepad} pad - A reference to the Gamepad on which the button was released.

--- a/src/input/gamepad/events/CONNECTED_EVENT.js
+++ b/src/input/gamepad/events/CONNECTED_EVENT.js
@@ -17,7 +17,7 @@
  * already connected.
  *
  * @event Phaser.Input.Gamepad.Events#CONNECTED
- * @type {string}
+ * @type {'connected'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Gamepad} pad - A reference to the Gamepad which was connected.

--- a/src/input/gamepad/events/DISCONNECTED_EVENT.js
+++ b/src/input/gamepad/events/DISCONNECTED_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to this event from within a Scene using: `this.input.gamepad.once('disconnected', listener)`.
  *
  * @event Phaser.Input.Gamepad.Events#DISCONNECTED
- * @type {string}
+ * @type {'disconnected'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Gamepad} pad - A reference to the Gamepad which was disconnected.

--- a/src/input/gamepad/events/GAMEPAD_BUTTON_DOWN_EVENT.js
+++ b/src/input/gamepad/events/GAMEPAD_BUTTON_DOWN_EVENT.js
@@ -17,7 +17,7 @@
  * You can also listen for a DOWN event from the Gamepad Plugin. See the [BUTTON_DOWN]{@linkcode Phaser.Input.Gamepad.Events#event:BUTTON_DOWN} event for details.
  *
  * @event Phaser.Input.Gamepad.Events#GAMEPAD_BUTTON_DOWN
- * @type {string}
+ * @type {'down'}
  * @since 3.10.0
  *
  * @param {number} index - The index of the button that was pressed.

--- a/src/input/gamepad/events/GAMEPAD_BUTTON_UP_EVENT.js
+++ b/src/input/gamepad/events/GAMEPAD_BUTTON_UP_EVENT.js
@@ -17,7 +17,7 @@
  * You can also listen for an UP event from the Gamepad Plugin. See the [BUTTON_UP]{@linkcode Phaser.Input.Gamepad.Events#event:BUTTON_UP} event for details.
  *
  * @event Phaser.Input.Gamepad.Events#GAMEPAD_BUTTON_UP
- * @type {string}
+ * @type {'up'}
  * @since 3.10.0
  *
  * @param {number} index - The index of the button that was released.

--- a/src/input/keyboard/events/ANY_KEY_DOWN_EVENT.js
+++ b/src/input/keyboard/events/ANY_KEY_DOWN_EVENT.js
@@ -23,7 +23,7 @@
  * There are others. So, please check your extensions if you find you have specific keys that don't work.
  *
  * @event Phaser.Input.Keyboard.Events#ANY_KEY_DOWN
- * @type {string}
+ * @type {'keydown'}
  * @since 3.0.0
  *
  * @param {KeyboardEvent} event - The native DOM Keyboard Event. You can inspect this to learn more about the key that was pressed, any modifiers, etc.

--- a/src/input/keyboard/events/ANY_KEY_UP_EVENT.js
+++ b/src/input/keyboard/events/ANY_KEY_UP_EVENT.js
@@ -16,7 +16,7 @@
  * Finally, you can create Key objects, which you can also listen for events from. See [Keyboard.Events.UP]{@linkcode Phaser.Input.Keyboard.Events#event:UP} for details.
  *
  * @event Phaser.Input.Keyboard.Events#ANY_KEY_UP
- * @type {string}
+ * @type {'keyup'}
  * @since 3.0.0
  *
  * @param {KeyboardEvent} event - The native DOM Keyboard Event. You can inspect this to learn more about the key that was released, any modifiers, etc.

--- a/src/input/keyboard/events/COMBO_MATCH_EVENT.js
+++ b/src/input/keyboard/events/COMBO_MATCH_EVENT.js
@@ -20,7 +20,7 @@
  * ```
  *
  * @event Phaser.Input.Keyboard.Events#COMBO_MATCH
- * @type {string}
+ * @type {'keycombomatch'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Keyboard.KeyCombo} keycombo - The Key Combo object that was matched.

--- a/src/input/keyboard/events/DOWN_EVENT.js
+++ b/src/input/keyboard/events/DOWN_EVENT.js
@@ -20,7 +20,7 @@
  * You can also create a generic 'global' listener. See [Keyboard.Events.ANY_KEY_DOWN]{@linkcode Phaser.Input.Keyboard.Events#event:ANY_KEY_DOWN} for details.
  *
  * @event Phaser.Input.Keyboard.Events#DOWN
- * @type {string}
+ * @type {'down'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Keyboard.Key} key - The Key object that was pressed.

--- a/src/input/keyboard/events/UP_EVENT.js
+++ b/src/input/keyboard/events/UP_EVENT.js
@@ -20,7 +20,7 @@
  * You can also create a generic 'global' listener. See [Keyboard.Events.ANY_KEY_UP]{@linkcode Phaser.Input.Keyboard.Events#event:ANY_KEY_UP} for details.
  *
  * @event Phaser.Input.Keyboard.Events#UP
- * @type {string}
+ * @type {'up'}
  * @since 3.0.0
  *
  * @param {Phaser.Input.Keyboard.Key} key - The Key object that was released.

--- a/src/loader/events/ADD_EVENT.js
+++ b/src/loader/events/ADD_EVENT.js
@@ -14,7 +14,7 @@
  * If you add lots of files to a Loader from a `preload` method, it will dispatch this event for each one of them.
  *
  * @event Phaser.Loader.Events#ADD
- * @type {string}
+ * @type {'addfile'}
  * @since 3.0.0
  *
  * @param {string} key - The unique key of the file that was added to the Loader.

--- a/src/loader/events/COMPLETE_EVENT.js
+++ b/src/loader/events/COMPLETE_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using: `this.load.on('complete', listener)`.
  *
  * @event Phaser.Loader.Events#COMPLETE
- * @type {string}
+ * @type {'complete'}
  * @since 3.0.0
  *
  * @param {Phaser.Loader.LoaderPlugin} loader - A reference to the Loader Plugin that dispatched this event.

--- a/src/loader/events/FILE_COMPLETE_EVENT.js
+++ b/src/loader/events/FILE_COMPLETE_EVENT.js
@@ -16,7 +16,7 @@
  * You can also listen for the completion of a specific file. See the [FILE_KEY_COMPLETE]{@linkcode Phaser.Loader.Events#event:FILE_KEY_COMPLETE} event.
  *
  * @event Phaser.Loader.Events#FILE_COMPLETE
- * @type {string}
+ * @type {'filecomplete'}
  * @since 3.0.0
  *
  * @param {string} key - The key of the file that just loaded and finished processing.

--- a/src/loader/events/FILE_LOAD_ERROR_EVENT.js
+++ b/src/loader/events/FILE_LOAD_ERROR_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Scene using: `this.load.on('loaderror', listener)`.
  *
  * @event Phaser.Loader.Events#FILE_LOAD_ERROR
- * @type {string}
+ * @type {'loaderror'}
  * @since 3.0.0
  *
  * @param {Phaser.Loader.File} file - A reference to the File which errored during load.

--- a/src/loader/events/FILE_LOAD_EVENT.js
+++ b/src/loader/events/FILE_LOAD_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using: `this.load.on('load', listener)`.
  *
  * @event Phaser.Loader.Events#FILE_LOAD
- * @type {string}
+ * @type {'load'}
  * @since 3.0.0
  *
  * @param {Phaser.Loader.File} file - A reference to the File which just finished loading.

--- a/src/loader/events/FILE_PROGRESS_EVENT.js
+++ b/src/loader/events/FILE_PROGRESS_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using: `this.load.on('fileprogress', listener)`.
  *
  * @event Phaser.Loader.Events#FILE_PROGRESS
- * @type {string}
+ * @type {'fileprogress'}
  * @since 3.0.0
  *
  * @param {Phaser.Loader.File} file - A reference to the File for which progress has been updated.

--- a/src/loader/events/POST_PROCESS_EVENT.js
+++ b/src/loader/events/POST_PROCESS_EVENT.js
@@ -16,7 +16,7 @@
  * Listen to it from a Scene using: `this.load.on('postprocess', listener)`.
  *
  * @event Phaser.Loader.Events#POST_PROCESS
- * @type {string}
+ * @type {'postprocess'}
  * @since 3.0.0
  *
  * @param {Phaser.Loader.LoaderPlugin} loader - A reference to the Loader Plugin that dispatched this event.

--- a/src/loader/events/PROGRESS_EVENT.js
+++ b/src/loader/events/PROGRESS_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Scene using: `this.load.on('progress', listener)`.
  *
  * @event Phaser.Loader.Events#PROGRESS
- * @type {string}
+ * @type {'progress'}
  * @since 3.0.0
  *
  * @param {number} progress - The current progress of the load. A value between 0 and 1.

--- a/src/loader/events/START_EVENT.js
+++ b/src/loader/events/START_EVENT.js
@@ -14,7 +14,7 @@
  * Listen to it from a Scene using: `this.load.on('start', listener)`.
  *
  * @event Phaser.Loader.Events#START
- * @type {string}
+ * @type {'start'}
  * @since 3.0.0
  *
  * @param {Phaser.Loader.LoaderPlugin} loader - A reference to the Loader Plugin that dispatched this event.

--- a/src/physics/arcade/events/COLLIDE_EVENT.js
+++ b/src/physics/arcade/events/COLLIDE_EVENT.js
@@ -17,7 +17,7 @@
  * Please note that 'collide' and 'overlap' are two different things in Arcade Physics.
  *
  * @event Phaser.Physics.Arcade.Events#COLLIDE
- * @type {string}
+ * @type {'collide'}
  * @since 3.0.0
  *
  * @param {Phaser.GameObjects.GameObject} gameObject1 - The first Game Object involved in the collision. This is the parent of `body1`.

--- a/src/physics/arcade/events/OVERLAP_EVENT.js
+++ b/src/physics/arcade/events/OVERLAP_EVENT.js
@@ -17,7 +17,7 @@
  * Please note that 'collide' and 'overlap' are two different things in Arcade Physics.
  *
  * @event Phaser.Physics.Arcade.Events#OVERLAP
- * @type {string}
+ * @type {'overlap'}
  * @since 3.0.0
  *
  * @param {Phaser.GameObjects.GameObject} gameObject1 - The first Game Object involved in the overlap. This is the parent of `body1`.

--- a/src/physics/arcade/events/PAUSE_EVENT.js
+++ b/src/physics/arcade/events/PAUSE_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Scene using: `this.physics.world.on('pause', listener)`.
  *
  * @event Phaser.Physics.Arcade.Events#PAUSE
- * @type {string}
+ * @type {'pause'}
  * @since 3.0.0
  */
 module.exports = 'pause';

--- a/src/physics/arcade/events/RESUME_EVENT.js
+++ b/src/physics/arcade/events/RESUME_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Scene using: `this.physics.world.on('resume', listener)`.
  *
  * @event Phaser.Physics.Arcade.Events#RESUME
- * @type {string}
+ * @type {'resume'}
  * @since 3.0.0
  */
 module.exports = 'resume';

--- a/src/physics/arcade/events/TILE_COLLIDE_EVENT.js
+++ b/src/physics/arcade/events/TILE_COLLIDE_EVENT.js
@@ -17,7 +17,7 @@
  * Please note that 'collide' and 'overlap' are two different things in Arcade Physics.
  *
  * @event Phaser.Physics.Arcade.Events#TILE_COLLIDE
- * @type {string}
+ * @type {'tilecollide'}
  * @since 3.16.1
  *
  * @param {Phaser.GameObjects.GameObject} gameObject - The Game Object involved in the collision. This is the parent of `body`.

--- a/src/physics/arcade/events/TILE_OVERLAP_EVENT.js
+++ b/src/physics/arcade/events/TILE_OVERLAP_EVENT.js
@@ -17,7 +17,7 @@
  * Please note that 'collide' and 'overlap' are two different things in Arcade Physics.
  *
  * @event Phaser.Physics.Arcade.Events#TILE_OVERLAP
- * @type {string}
+ * @type {'tileoverlap'}
  * @since 3.16.1
  *
  * @param {Phaser.GameObjects.GameObject} gameObject - The Game Object involved in the overlap. This is the parent of `body`.

--- a/src/physics/arcade/events/WORLD_BOUNDS_EVENT.js
+++ b/src/physics/arcade/events/WORLD_BOUNDS_EVENT.js
@@ -15,7 +15,7 @@
  * Listen to it from a Scene using: `this.physics.world.on('worldbounds', listener)`.
  *
  * @event Phaser.Physics.Arcade.Events#WORLD_BOUNDS
- * @type {string}
+ * @type {'worldbounds'}
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Arcade.Body} body - The Arcade Physics Body that hit the world bounds.

--- a/src/physics/arcade/events/WORLD_STEP_EVENT.js
+++ b/src/physics/arcade/events/WORLD_STEP_EVENT.js
@@ -15,7 +15,7 @@
  * Listen to it from a Scene using: `this.physics.world.on('worldstep', listener)`.
  *
  * @event Phaser.Physics.Arcade.Events#WORLD_STEP
- * @type {string}
+ * @type {'worldstep'}
  * @since 3.18.0
  *
  * @param {number} delta - The delta time amount of this step, in seconds.

--- a/src/physics/matter-js/events/AFTER_ADD_EVENT.js
+++ b/src/physics/matter-js/events/AFTER_ADD_EVENT.js
@@ -21,7 +21,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('afteradd', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#AFTER_ADD
- * @type {string}
+ * @type {'afteradd'}
  * @since 3.22.0
  *
  * @param {Phaser.Physics.Matter.Events.AfterAddEvent} event - The Add Event object.

--- a/src/physics/matter-js/events/AFTER_REMOVE_EVENT.js
+++ b/src/physics/matter-js/events/AFTER_REMOVE_EVENT.js
@@ -21,7 +21,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('afterremove', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#AFTER_REMOVE
- * @type {string}
+ * @type {'afterremove'}
  * @since 3.22.0
  *
  * @param {Phaser.Physics.Matter.Events.AfterRemoveEvent} event - The Remove Event object.

--- a/src/physics/matter-js/events/AFTER_UPDATE_EVENT.js
+++ b/src/physics/matter-js/events/AFTER_UPDATE_EVENT.js
@@ -20,7 +20,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('afterupdate', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#AFTER_UPDATE
- * @type {string}
+ * @type {'afterupdate'}
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Matter.Events.AfterUpdateEvent} event - The Update Event object.

--- a/src/physics/matter-js/events/BEFORE_ADD_EVENT.js
+++ b/src/physics/matter-js/events/BEFORE_ADD_EVENT.js
@@ -21,7 +21,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('beforeadd', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#BEFORE_ADD
- * @type {string}
+ * @type {'beforeadd'}
  * @since 3.22.0
  *
  * @param {Phaser.Physics.Matter.Events.BeforeAddEvent} event - The Add Event object.

--- a/src/physics/matter-js/events/BEFORE_REMOVE_EVENT.js
+++ b/src/physics/matter-js/events/BEFORE_REMOVE_EVENT.js
@@ -21,7 +21,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('beforeremove', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#BEFORE_REMOVE
- * @type {string}
+ * @type {'beforeremove'}
  * @since 3.22.0
  *
  * @param {Phaser.Physics.Matter.Events.BeforeRemoveEvent} event - The Remove Event object.

--- a/src/physics/matter-js/events/BEFORE_UPDATE_EVENT.js
+++ b/src/physics/matter-js/events/BEFORE_UPDATE_EVENT.js
@@ -20,7 +20,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('beforeupdate', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#BEFORE_UPDATE
- * @type {string}
+ * @type {'beforeupdate'}
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Matter.Events.BeforeUpdateEvent} event - The Update Event object.

--- a/src/physics/matter-js/events/COLLISION_ACTIVE_EVENT.js
+++ b/src/physics/matter-js/events/COLLISION_ACTIVE_EVENT.js
@@ -22,7 +22,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('collisionactive', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#COLLISION_ACTIVE
- * @type {string}
+ * @type {'collisionactive'}
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Matter.Events.CollisionActiveEvent} event - The Collision Event object.

--- a/src/physics/matter-js/events/COLLISION_END_EVENT.js
+++ b/src/physics/matter-js/events/COLLISION_END_EVENT.js
@@ -22,7 +22,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('collisionend', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#COLLISION_END
- * @type {string}
+ * @type {'collisionend'}
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Matter.Events.CollisionEndEvent} event - The Collision Event object.

--- a/src/physics/matter-js/events/COLLISION_START_EVENT.js
+++ b/src/physics/matter-js/events/COLLISION_START_EVENT.js
@@ -22,7 +22,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('collisionstart', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#COLLISION_START
- * @type {string}
+ * @type {'collisionstart'}
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Matter.Events.CollisionStartEvent} event - The Collision Event object.

--- a/src/physics/matter-js/events/DRAG_END_EVENT.js
+++ b/src/physics/matter-js/events/DRAG_END_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('dragend', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#DRAG_END
- * @type {string}
+ * @type {'dragend'}
  * @since 3.16.2
  *
  * @param {MatterJS.BodyType} body - The Body that has stopped being dragged. This is a Matter Body, not a Phaser Game Object.

--- a/src/physics/matter-js/events/DRAG_EVENT.js
+++ b/src/physics/matter-js/events/DRAG_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('drag', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#DRAG
- * @type {string}
+ * @type {'drag'}
  * @since 3.16.2
  *
  * @param {MatterJS.BodyType} body - The Body that is being dragged. This is a Matter Body, not a Phaser Game Object.

--- a/src/physics/matter-js/events/DRAG_START_EVENT.js
+++ b/src/physics/matter-js/events/DRAG_START_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('dragstart', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#DRAG_START
- * @type {string}
+ * @type {'dragstart'}
  * @since 3.16.2
  *
  * @param {MatterJS.BodyType} body - The Body that has started being dragged. This is a Matter Body, not a Phaser Game Object.

--- a/src/physics/matter-js/events/PAUSE_EVENT.js
+++ b/src/physics/matter-js/events/PAUSE_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('pause', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#PAUSE
- * @type {string}
+ * @type {'pause'}
  * @since 3.0.0
  */
 module.exports = 'pause';

--- a/src/physics/matter-js/events/RESUME_EVENT.js
+++ b/src/physics/matter-js/events/RESUME_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('resume', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#RESUME
- * @type {string}
+ * @type {'resume'}
  * @since 3.0.0
  */
 module.exports = 'resume';

--- a/src/physics/matter-js/events/SLEEP_END_EVENT.js
+++ b/src/physics/matter-js/events/SLEEP_END_EVENT.js
@@ -19,7 +19,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('sleepend', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#SLEEP_END
- * @type {string}
+ * @type {'sleepend'}
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Matter.Events.SleepEndEvent} event - The Sleep Event object.

--- a/src/physics/matter-js/events/SLEEP_START_EVENT.js
+++ b/src/physics/matter-js/events/SLEEP_START_EVENT.js
@@ -19,7 +19,7 @@
  * Listen to it from a Scene using: `this.matter.world.on('sleepstart', listener)`.
  *
  * @event Phaser.Physics.Matter.Events#SLEEP_START
- * @type {string}
+ * @type {'sleepstart'}
  * @since 3.0.0
  *
  * @param {Phaser.Physics.Matter.Events.SleepStartEvent} event - The Sleep Event object.

--- a/src/renderer/events/LOSE_WEBGL_EVENT.js
+++ b/src/renderer/events/LOSE_WEBGL_EVENT.js
@@ -22,7 +22,7 @@
  * it is safe to continue.
  *
  * @event Phaser.Renderer.Events#LOSE_WEBGL
- * @type {string}
+ * @type {'losewebgl'}
  * @since 3.80.0
  *
  * @param {Phaser.Renderer.WebGL.WebGLRenderer} renderer - the renderer that owns the WebGL context

--- a/src/renderer/events/POST_RENDER_EVENT.js
+++ b/src/renderer/events/POST_RENDER_EVENT.js
@@ -11,7 +11,7 @@
  * has completed, but before any pending snapshots have been taken.
  *
  * @event Phaser.Renderer.Events#POST_RENDER
- * @type {string}
+ * @type {'postrender'}
  * @since 3.50.0
  */
 module.exports = 'postrender';

--- a/src/renderer/events/PRE_RENDER_CLEAR_EVENT.js
+++ b/src/renderer/events/PRE_RENDER_CLEAR_EVENT.js
@@ -10,17 +10,17 @@
  * This event is dispatched by the Phaser Renderer. It happens at the start of the render step, before
  * the WebGL gl.clear function has been called. This allows you to toggle the `config.clearBeforeRender` property
  * as required, to have fine-grained control over when the canvas is cleared during rendering.
- * 
+ *
  * Listen to it from within a Scene using: `this.renderer.events.on('prerenderclear', listener)`.
- * 
+ *
  * It's very important to understand that this event is called _before_ the scissor and mask stacks are cleared.
  * This means you should not use this event to modify the scissor or mask. Instead, use the `prerender` event for that.
- * 
+ *
  * If using the Canvas Renderer, this event is dispatched before the canvas is cleared, but after the context globalAlpha
  * and transform have been reset.
  *
  * @event Phaser.Renderer.Events#PRE_RENDER_CLEAR
- * @type {string}
+ * @type {'prerenderclear'}
  * @since 3.85.0
  */
 module.exports = 'prerenderclear';

--- a/src/renderer/events/PRE_RENDER_EVENT.js
+++ b/src/renderer/events/PRE_RENDER_EVENT.js
@@ -12,7 +12,7 @@
  * reset ready for the render.
  *
  * @event Phaser.Renderer.Events#PRE_RENDER
- * @type {string}
+ * @type {'prerender'}
  * @since 3.50.0
  */
 module.exports = 'prerender';

--- a/src/renderer/events/RENDER_EVENT.js
+++ b/src/renderer/events/RENDER_EVENT.js
@@ -12,7 +12,7 @@
  * It is dispatched before any of the children in the Scene have been rendered.
  *
  * @event Phaser.Renderer.Events#RENDER
- * @type {string}
+ * @type {'render'}
  * @since 3.50.0
  *
  * @param {Phaser.Scene} scene - The Scene being rendered.

--- a/src/renderer/events/RESIZE_EVENT.js
+++ b/src/renderer/events/RESIZE_EVENT.js
@@ -11,7 +11,7 @@
  * of the Scale Manager resizing.
  *
  * @event Phaser.Renderer.Events#RESIZE
- * @type {string}
+ * @type {'resize'}
  * @since 3.50.0
  *
  * @param {number} width - The new width of the renderer.

--- a/src/renderer/events/RESTORE_WEBGL_EVENT.js
+++ b/src/renderer/events/RESTORE_WEBGL_EVENT.js
@@ -25,7 +25,7 @@
  * re-creating any resources of your own.
  *
  * @event Phaser.Renderer.Events#RESTORE_WEBGL
- * @type {string}
+ * @type {'restorewebgl'}
  * @since 3.80.0
  *
  * @param {Phaser.Renderer.WebGL.WebGLRenderer} renderer - the renderer that owns the WebGL context

--- a/src/renderer/events/SET_PARALLEL_TEXTURE_UNITS_EVENT.js
+++ b/src/renderer/events/SET_PARALLEL_TEXTURE_UNITS_EVENT.js
@@ -20,7 +20,7 @@
  * The primary consumer of this event is batch render nodes.
  *
  * @event Phaser.Renderer.Events#SET_PARALLEL_TEXTURE_UNITS
- * @type {string}
+ * @type {'setparalleltextureunits'}
  * @since 4.0.0
  *
  * @param {number} units - The number of texture units advised.

--- a/src/scale/events/ENTER_FULLSCREEN_EVENT.js
+++ b/src/scale/events/ENTER_FULLSCREEN_EVENT.js
@@ -8,7 +8,7 @@
  * The Scale Manager has successfully entered fullscreen mode.
  *
  * @event Phaser.Scale.Events#ENTER_FULLSCREEN
- * @type {string}
+ * @type {'enterfullscreen'}
  * @since 3.16.1
  */
 module.exports = 'enterfullscreen';

--- a/src/scale/events/FULLSCREEN_FAILED_EVENT.js
+++ b/src/scale/events/FULLSCREEN_FAILED_EVENT.js
@@ -8,7 +8,7 @@
  * The Scale Manager tried to enter fullscreen mode but failed.
  *
  * @event Phaser.Scale.Events#FULLSCREEN_FAILED
- * @type {string}
+ * @type {'fullscreenfailed'}
  * @since 3.17.0
  */
 module.exports = 'fullscreenfailed';

--- a/src/scale/events/FULLSCREEN_UNSUPPORTED_EVENT.js
+++ b/src/scale/events/FULLSCREEN_UNSUPPORTED_EVENT.js
@@ -8,7 +8,7 @@
  * The Scale Manager tried to enter fullscreen mode, but it is unsupported by the browser.
  *
  * @event Phaser.Scale.Events#FULLSCREEN_UNSUPPORTED
- * @type {string}
+ * @type {'fullscreenunsupported'}
  * @since 3.16.1
  */
 module.exports = 'fullscreenunsupported';

--- a/src/scale/events/LEAVE_FULLSCREEN_EVENT.js
+++ b/src/scale/events/LEAVE_FULLSCREEN_EVENT.js
@@ -9,7 +9,7 @@
  * or via a user gestured, such as pressing the ESC key.
  *
  * @event Phaser.Scale.Events#LEAVE_FULLSCREEN
- * @type {string}
+ * @type {'leavefullscreen'}
  * @since 3.16.1
  */
 module.exports = 'leavefullscreen';

--- a/src/scale/events/ORIENTATION_CHANGE_EVENT.js
+++ b/src/scale/events/ORIENTATION_CHANGE_EVENT.js
@@ -10,7 +10,7 @@
  * This event is dispatched whenever the Scale Manager detects an orientation change event from the browser.
  *
  * @event Phaser.Scale.Events#ORIENTATION_CHANGE
- * @type {string}
+ * @type {'orientationchange'}
  * @since 3.16.1
  *
  * @param {string} orientation - The new orientation value. Either `Phaser.Scale.Orientation.LANDSCAPE` or `Phaser.Scale.Orientation.PORTRAIT`.

--- a/src/scale/events/RESIZE_EVENT.js
+++ b/src/scale/events/RESIZE_EVENT.js
@@ -13,7 +13,7 @@
  * scaling your own game content.
  *
  * @event Phaser.Scale.Events#RESIZE
- * @type {string}
+ * @type {'resize'}
  * @since 3.16.1
  *
  * @param {Phaser.Structs.Size} gameSize - A reference to the Game Size component. This is the un-scaled size of your game canvas.

--- a/src/scene/events/ADDED_TO_SCENE_EVENT.js
+++ b/src/scene/events/ADDED_TO_SCENE_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it from a Scene using `this.events.on('addedtoscene', listener)`.
  *
  * @event Phaser.Scenes.Events#ADDED_TO_SCENE
- * @type {string}
+ * @type {'addedtoscene'}
  * @since 3.50.0
  *
  * @param {Phaser.GameObjects.GameObject} gameObject - The Game Object that was added to the Scene.

--- a/src/scene/events/BOOT_EVENT.js
+++ b/src/scene/events/BOOT_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Scene using `this.events.on('boot', listener)`.
  *
  * @event Phaser.Scenes.Events#BOOT
- * @type {string}
+ * @type {'boot'}
  * @since 3.0.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/scene/events/CREATE_EVENT.js
+++ b/src/scene/events/CREATE_EVENT.js
@@ -16,7 +16,7 @@
  * Listen to it from a Scene using `this.events.on('create', listener)`.
  *
  * @event Phaser.Scenes.Events#CREATE
- * @type {string}
+ * @type {'create'}
  * @since 3.17.0
  *
  * @param {Phaser.Scene} scene - A reference to the Scene that emitted this event.

--- a/src/scene/events/DESTROY_EVENT.js
+++ b/src/scene/events/DESTROY_EVENT.js
@@ -14,7 +14,7 @@
  * You should destroy any resources that may be in use by your Scene in this event handler.
  *
  * @event Phaser.Scenes.Events#DESTROY
- * @type {string}
+ * @type {'destroy'}
  * @since 3.0.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/scene/events/PAUSE_EVENT.js
+++ b/src/scene/events/PAUSE_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using `this.events.on('pause', listener)`.
  *
  * @event Phaser.Scenes.Events#PAUSE
- * @type {string}
+ * @type {'pause'}
  * @since 3.0.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/scene/events/POST_UPDATE_EVENT.js
+++ b/src/scene/events/POST_UPDATE_EVENT.js
@@ -23,7 +23,7 @@
  * A Scene will only run its step if it is active.
  *
  * @event Phaser.Scenes.Events#POST_UPDATE
- * @type {string}
+ * @type {'postupdate'}
  * @since 3.0.0
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/scene/events/PRE_RENDER_EVENT.js
+++ b/src/scene/events/PRE_RENDER_EVENT.js
@@ -25,7 +25,7 @@
  * This event is dispatched after the Scene Display List is sorted and before the Scene is rendered.
  *
  * @event Phaser.Scenes.Events#PRE_RENDER
- * @type {string}
+ * @type {'prerender'}
  * @since 3.53.0
  *
  * @param {(Phaser.Renderer.Canvas.CanvasRenderer|Phaser.Renderer.WebGL.WebGLRenderer)} renderer - The renderer that rendered the Scene.

--- a/src/scene/events/PRE_UPDATE_EVENT.js
+++ b/src/scene/events/PRE_UPDATE_EVENT.js
@@ -23,7 +23,7 @@
  * A Scene will only run its step if it is active.
  *
  * @event Phaser.Scenes.Events#PRE_UPDATE
- * @type {string}
+ * @type {'preupdate'}
  * @since 3.0.0
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/scene/events/READY_EVENT.js
+++ b/src/scene/events/READY_EVENT.js
@@ -14,7 +14,7 @@
  * Listen to it from a Scene using `this.events.on('ready', listener)`.
  *
  * @event Phaser.Scenes.Events#READY
- * @type {string}
+ * @type {'ready'}
  * @since 3.0.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/scene/events/REMOVED_FROM_SCENE_EVENT.js
+++ b/src/scene/events/REMOVED_FROM_SCENE_EVENT.js
@@ -12,7 +12,7 @@
  * Listen for it from a Scene using `this.events.on('removedfromscene', listener)`.
  *
  * @event Phaser.Scenes.Events#REMOVED_FROM_SCENE
- * @type {string}
+ * @type {'removedfromscene'}
  * @since 3.50.0
  *
  * @param {Phaser.GameObjects.GameObject} gameObject - The Game Object that was removed from the Scene.

--- a/src/scene/events/RENDER_EVENT.js
+++ b/src/scene/events/RENDER_EVENT.js
@@ -25,7 +25,7 @@
  * By the time this event is dispatched, the Scene will have already been rendered.
  *
  * @event Phaser.Scenes.Events#RENDER
- * @type {string}
+ * @type {'render'}
  * @since 3.0.0
  *
  * @param {(Phaser.Renderer.Canvas.CanvasRenderer|Phaser.Renderer.WebGL.WebGLRenderer)} renderer - The renderer that rendered the Scene.

--- a/src/scene/events/RESUME_EVENT.js
+++ b/src/scene/events/RESUME_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using `this.events.on('resume', listener)`.
  *
  * @event Phaser.Scenes.Events#RESUME
- * @type {string}
+ * @type {'resume'}
  * @since 3.0.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/scene/events/SHUTDOWN_EVENT.js
+++ b/src/scene/events/SHUTDOWN_EVENT.js
@@ -16,7 +16,7 @@
  * currently active. Use the [DESTROY]{@linkcode Phaser.Scenes.Events#event:DESTROY} event to completely clear resources.
  *
  * @event Phaser.Scenes.Events#SHUTDOWN
- * @type {string}
+ * @type {'shutdown'}
  * @since 3.0.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/scene/events/SLEEP_EVENT.js
+++ b/src/scene/events/SLEEP_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using `this.events.on('sleep', listener)`.
  *
  * @event Phaser.Scenes.Events#SLEEP
- * @type {string}
+ * @type {'sleep'}
  * @since 3.0.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/scene/events/START_EVENT.js
+++ b/src/scene/events/START_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to it from a Scene using `this.events.on('start', listener)`.
  *
  * @event Phaser.Scenes.Events#START
- * @type {string}
+ * @type {'start'}
  * @since 3.0.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/scene/events/TRANSITION_COMPLETE_EVENT.js
+++ b/src/scene/events/TRANSITION_COMPLETE_EVENT.js
@@ -23,7 +23,7 @@
  * 5. [TRANSITION_COMPLETE]{@linkcode Phaser.Scenes.Events#event:TRANSITION_COMPLETE} - the Target Scene will emit this event when the transition finishes.
  *
  * @event Phaser.Scenes.Events#TRANSITION_COMPLETE
- * @type {string}
+ * @type {'transitioncomplete'}
  * @since 3.5.0
  *
  * @param {Phaser.Scene} scene -The Scene on which the transitioned completed.

--- a/src/scene/events/TRANSITION_INIT_EVENT.js
+++ b/src/scene/events/TRANSITION_INIT_EVENT.js
@@ -23,7 +23,7 @@
  * 5. [TRANSITION_COMPLETE]{@linkcode Phaser.Scenes.Events#event:TRANSITION_COMPLETE} - the Target Scene will emit this event when the transition finishes.
  *
  * @event Phaser.Scenes.Events#TRANSITION_INIT
- * @type {string}
+ * @type {'transitioninit'}
  * @since 3.5.0
  *
  * @param {Phaser.Scene} from - A reference to the Scene that is being transitioned from.

--- a/src/scene/events/TRANSITION_OUT_EVENT.js
+++ b/src/scene/events/TRANSITION_OUT_EVENT.js
@@ -20,7 +20,7 @@
  * 5. [TRANSITION_COMPLETE]{@linkcode Phaser.Scenes.Events#event:TRANSITION_COMPLETE} - the Target Scene will emit this event when the transition finishes.
  *
  * @event Phaser.Scenes.Events#TRANSITION_OUT
- * @type {string}
+ * @type {'transitionout'}
  * @since 3.5.0
  *
  * @param {Phaser.Scene} target - A reference to the Scene that is being transitioned to.

--- a/src/scene/events/TRANSITION_START_EVENT.js
+++ b/src/scene/events/TRANSITION_START_EVENT.js
@@ -26,7 +26,7 @@
  * 5. [TRANSITION_COMPLETE]{@linkcode Phaser.Scenes.Events#event:TRANSITION_COMPLETE} - the Target Scene will emit this event when the transition finishes.
  *
  * @event Phaser.Scenes.Events#TRANSITION_START
- * @type {string}
+ * @type {'transitionstart'}
  * @since 3.5.0
  *
  * @param {Phaser.Scene} from - A reference to the Scene that is being transitioned from.

--- a/src/scene/events/TRANSITION_WAKE_EVENT.js
+++ b/src/scene/events/TRANSITION_WAKE_EVENT.js
@@ -21,7 +21,7 @@
  * 5. [TRANSITION_COMPLETE]{@linkcode Phaser.Scenes.Events#event:TRANSITION_COMPLETE} - the Target Scene will emit this event when the transition finishes.
  *
  * @event Phaser.Scenes.Events#TRANSITION_WAKE
- * @type {string}
+ * @type {'transitionwake'}
  * @since 3.5.0
  *
  * @param {Phaser.Scene} from - A reference to the Scene that is being transitioned from.

--- a/src/scene/events/UPDATE_EVENT.js
+++ b/src/scene/events/UPDATE_EVENT.js
@@ -23,7 +23,7 @@
  * A Scene will only run its step if it is active.
  *
  * @event Phaser.Scenes.Events#UPDATE
- * @type {string}
+ * @type {'update'}
  * @since 3.0.0
  *
  * @param {number} time - The current time. Either a High Resolution Timer value if it comes from Request Animation Frame, or Date.now if using SetTimeout.

--- a/src/scene/events/WAKE_EVENT.js
+++ b/src/scene/events/WAKE_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using `this.events.on('wake', listener)`.
  *
  * @event Phaser.Scenes.Events#WAKE
- * @type {string}
+ * @type {'wake'}
  * @since 3.0.0
  *
  * @param {Phaser.Scenes.Systems} sys - A reference to the Scene Systems class of the Scene that emitted this event.

--- a/src/sound/events/COMPLETE_EVENT.js
+++ b/src/sound/events/COMPLETE_EVENT.js
@@ -18,7 +18,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#COMPLETE
- * @type {string}
+ * @type {'complete'}
  * @since 3.16.1
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/DECODED_ALL_EVENT.js
+++ b/src/sound/events/DECODED_ALL_EVENT.js
@@ -21,7 +21,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#DECODED_ALL
- * @type {string}
+ * @type {'decodedall'}
  * @since 3.18.0
  */
 module.exports = 'decodedall';

--- a/src/sound/events/DECODED_EVENT.js
+++ b/src/sound/events/DECODED_EVENT.js
@@ -17,7 +17,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#DECODED
- * @type {string}
+ * @type {'decoded'}
  * @since 3.18.0
  *
  * @param {string} key - The key of the audio file that was decoded and added to the audio cache.

--- a/src/sound/events/DESTROY_EVENT.js
+++ b/src/sound/events/DESTROY_EVENT.js
@@ -19,7 +19,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#DESTROY
- * @type {string}
+ * @type {'destroy'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/DETUNE_EVENT.js
+++ b/src/sound/events/DETUNE_EVENT.js
@@ -19,7 +19,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#DETUNE
- * @type {string}
+ * @type {'detune'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/GLOBAL_DETUNE_EVENT.js
+++ b/src/sound/events/GLOBAL_DETUNE_EVENT.js
@@ -14,7 +14,7 @@
  * Listen to it from a Scene using: `this.sound.on('detune', listener)`.
  *
  * @event Phaser.Sound.Events#GLOBAL_DETUNE
- * @type {string}
+ * @type {'detune'}
  * @since 3.0.0
  *
  * @param {Phaser.Sound.BaseSoundManager} soundManager - A reference to the sound manager that emitted the event.

--- a/src/sound/events/GLOBAL_MUTE_EVENT.js
+++ b/src/sound/events/GLOBAL_MUTE_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using: `this.sound.on('mute', listener)`.
  *
  * @event Phaser.Sound.Events#GLOBAL_MUTE
- * @type {string}
+ * @type {'mute'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSoundManager|Phaser.Sound.HTML5AudioSoundManager)} soundManager - A reference to the Sound Manager that emitted the event.

--- a/src/sound/events/GLOBAL_RATE_EVENT.js
+++ b/src/sound/events/GLOBAL_RATE_EVENT.js
@@ -14,7 +14,7 @@
  * Listen to it from a Scene using: `this.sound.on('rate', listener)`.
  *
  * @event Phaser.Sound.Events#GLOBAL_RATE
- * @type {string}
+ * @type {'rate'}
  * @since 3.0.0
  *
  * @param {Phaser.Sound.BaseSoundManager} soundManager - A reference to the sound manager that emitted the event.

--- a/src/sound/events/GLOBAL_VOLUME_EVENT.js
+++ b/src/sound/events/GLOBAL_VOLUME_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to it from a Scene using: `this.sound.on('volume', listener)`.
  *
  * @event Phaser.Sound.Events#GLOBAL_VOLUME
- * @type {string}
+ * @type {'volume'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSoundManager|Phaser.Sound.HTML5AudioSoundManager)} soundManager - A reference to the sound manager that emitted the event.

--- a/src/sound/events/LOOPED_EVENT.js
+++ b/src/sound/events/LOOPED_EVENT.js
@@ -21,7 +21,7 @@
  * This is not to be confused with the [LOOP]{@linkcode Phaser.Sound.Events#event:LOOP} event, which only emits when the loop state of a Sound is changed.
  *
  * @event Phaser.Sound.Events#LOOPED
- * @type {string}
+ * @type {'looped'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/LOOP_EVENT.js
+++ b/src/sound/events/LOOP_EVENT.js
@@ -20,7 +20,7 @@
  * This is not to be confused with the [LOOPED]{@linkcode Phaser.Sound.Events#event:LOOPED} event, which emits each time a Sound loops during playback.
  *
  * @event Phaser.Sound.Events#LOOP
- * @type {string}
+ * @type {'loop'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/MUTE_EVENT.js
+++ b/src/sound/events/MUTE_EVENT.js
@@ -19,7 +19,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#MUTE
- * @type {string}
+ * @type {'mute'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/PAN_EVENT.js
+++ b/src/sound/events/PAN_EVENT.js
@@ -19,7 +19,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#PAN
- * @type {string}
+ * @type {'pan'}
  * @since 3.50.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/PAUSE_ALL_EVENT.js
+++ b/src/sound/events/PAUSE_ALL_EVENT.js
@@ -14,7 +14,7 @@
  * Listen to it from a Scene using: `this.sound.on('pauseall', listener)`.
  *
  * @event Phaser.Sound.Events#PAUSE_ALL
- * @type {string}
+ * @type {'pauseall'}
  * @since 3.0.0
  *
  * @param {Phaser.Sound.BaseSoundManager} soundManager - A reference to the sound manager that emitted the event.

--- a/src/sound/events/PAUSE_EVENT.js
+++ b/src/sound/events/PAUSE_EVENT.js
@@ -19,7 +19,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#PAUSE
- * @type {string}
+ * @type {'pause'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/PLAY_EVENT.js
+++ b/src/sound/events/PLAY_EVENT.js
@@ -18,7 +18,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#PLAY
- * @type {string}
+ * @type {'play'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/RATE_EVENT.js
+++ b/src/sound/events/RATE_EVENT.js
@@ -19,7 +19,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#RATE
- * @type {string}
+ * @type {'rate'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/RESUME_ALL_EVENT.js
+++ b/src/sound/events/RESUME_ALL_EVENT.js
@@ -14,7 +14,7 @@
  * Listen to it from a Scene using: `this.sound.on('resumeall', listener)`.
  *
  * @event Phaser.Sound.Events#RESUME_ALL
- * @type {string}
+ * @type {'resumeall'}
  * @since 3.0.0
  *
  * @param {Phaser.Sound.BaseSoundManager} soundManager - A reference to the sound manager that emitted the event.

--- a/src/sound/events/RESUME_EVENT.js
+++ b/src/sound/events/RESUME_EVENT.js
@@ -20,7 +20,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#RESUME
- * @type {string}
+ * @type {'resume'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/SEEK_EVENT.js
+++ b/src/sound/events/SEEK_EVENT.js
@@ -19,7 +19,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#SEEK
- * @type {string}
+ * @type {'seek'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/STOP_ALL_EVENT.js
+++ b/src/sound/events/STOP_ALL_EVENT.js
@@ -14,7 +14,7 @@
  * Listen to it from a Scene using: `this.sound.on('stopall', listener)`.
  *
  * @event Phaser.Sound.Events#STOP_ALL
- * @type {string}
+ * @type {'stopall'}
  * @since 3.0.0
  *
  * @param {Phaser.Sound.BaseSoundManager} soundManager - A reference to the sound manager that emitted the event.

--- a/src/sound/events/STOP_EVENT.js
+++ b/src/sound/events/STOP_EVENT.js
@@ -19,7 +19,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#STOP
- * @type {string}
+ * @type {'stop'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/sound/events/UNLOCKED_EVENT.js
+++ b/src/sound/events/UNLOCKED_EVENT.js
@@ -14,7 +14,7 @@
  * Listen to it from a Scene using: `this.sound.on('unlocked', listener)`.
  *
  * @event Phaser.Sound.Events#UNLOCKED
- * @type {string}
+ * @type {'unlocked'}
  * @since 3.0.0
  *
  * @param {Phaser.Sound.BaseSoundManager} soundManager - A reference to the sound manager that emitted the event.

--- a/src/sound/events/VOLUME_EVENT.js
+++ b/src/sound/events/VOLUME_EVENT.js
@@ -19,7 +19,7 @@
  * ```
  *
  * @event Phaser.Sound.Events#VOLUME
- * @type {string}
+ * @type {'volume'}
  * @since 3.0.0
  *
  * @param {(Phaser.Sound.WebAudioSound|Phaser.Sound.HTML5AudioSound)} sound - A reference to the Sound that emitted the event.

--- a/src/structs/events/PROCESS_QUEUE_ADD_EVENT.js
+++ b/src/structs/events/PROCESS_QUEUE_ADD_EVENT.js
@@ -14,7 +14,7 @@
  * In that instance, listen to this event from within a Scene using: `this.sys.updateList.on('add', listener)`.
  *
  * @event Phaser.Structs.Events#PROCESS_QUEUE_ADD
- * @type {string}
+ * @type {'add'}
  * @since 3.20.0
  *
  * @param {*} item - The item that was added to the Process Queue.

--- a/src/structs/events/PROCESS_QUEUE_REMOVE_EVENT.js
+++ b/src/structs/events/PROCESS_QUEUE_REMOVE_EVENT.js
@@ -14,7 +14,7 @@
  * In that instance, listen to this event from within a Scene using: `this.sys.updateList.on('remove', listener)`.
  *
  * @event Phaser.Structs.Events#PROCESS_QUEUE_REMOVE
- * @type {string}
+ * @type {'remove'}
  * @since 3.20.0
  *
  * @param {*} item - The item that was removed from the Process Queue.

--- a/src/textures/events/ADD_EVENT.js
+++ b/src/textures/events/ADD_EVENT.js
@@ -12,7 +12,7 @@
  * Listen to this event from within a Scene using: `this.textures.on('addtexture', listener)`.
  *
  * @event Phaser.Textures.Events#ADD
- * @type {string}
+ * @type {'addtexture'}
  * @since 3.0.0
  *
  * @param {string} key - The key of the Texture that was added to the Texture Manager.

--- a/src/textures/events/ERROR_EVENT.js
+++ b/src/textures/events/ERROR_EVENT.js
@@ -13,7 +13,7 @@
  * Listen to this event from within a Scene using: `this.textures.on('onerror', listener)`.
  *
  * @event Phaser.Textures.Events#ERROR
- * @type {string}
+ * @type {'onerror'}
  * @since 3.0.0
  *
  * @param {string} key - The key of the Texture that failed to load into the Texture Manager.

--- a/src/textures/events/LOAD_EVENT.js
+++ b/src/textures/events/LOAD_EVENT.js
@@ -15,7 +15,7 @@
  * This event is dispatched after the [ADD]{@linkcode Phaser.Textures.Events#event:ADD} event.
  *
  * @event Phaser.Textures.Events#LOAD
- * @type {string}
+ * @type {'onload'}
  * @since 3.0.0
  *
  * @param {string} key - The key of the Texture that was loaded by the Texture Manager.

--- a/src/textures/events/READY_EVENT.js
+++ b/src/textures/events/READY_EVENT.js
@@ -12,7 +12,7 @@
  * instance, which tells the Game to carry on booting.
  *
  * @event Phaser.Textures.Events#READY
- * @type {string}
+ * @type {'ready'}
  * @since 3.16.1
  */
 module.exports = 'ready';

--- a/src/textures/events/REMOVE_EVENT.js
+++ b/src/textures/events/REMOVE_EVENT.js
@@ -15,7 +15,7 @@
  * errors the next time they try to render. Be sure to clear all use of the texture in this event handler.
  *
  * @event Phaser.Textures.Events#REMOVE
- * @type {string}
+ * @type {'removetexture'}
  * @since 3.0.0
  *
  * @param {string} key - The key of the Texture that was removed from the Texture Manager.

--- a/src/time/events/COMPLETE_EVENT.js
+++ b/src/time/events/COMPLETE_EVENT.js
@@ -18,7 +18,7 @@
  * ```
  *
  * @event Phaser.Time.Events#COMPLETE
- * @type {string}
+ * @type {'complete'}
  * @since 3.70.0
  *
  * @param {Phaser.Time.Timeline} timeline - A reference to the Timeline that emitted the event.

--- a/src/tweens/events/TWEEN_ACTIVE_EVENT.js
+++ b/src/tweens/events/TWEEN_ACTIVE_EVENT.js
@@ -30,7 +30,7 @@
  * meant for use with `tweens.create()` and/or `tweens.existing()`.
  *
  * @event Phaser.Tweens.Events#TWEEN_ACTIVE
- * @type {string}
+ * @type {'active'}
  * @since 3.19.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.

--- a/src/tweens/events/TWEEN_COMPLETE_EVENT.js
+++ b/src/tweens/events/TWEEN_COMPLETE_EVENT.js
@@ -27,7 +27,7 @@
  * ```
  *
  * @event Phaser.Tweens.Events#TWEEN_COMPLETE
- * @type {string}
+ * @type {'complete'}
  * @since 3.19.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.

--- a/src/tweens/events/TWEEN_LOOP_EVENT.js
+++ b/src/tweens/events/TWEEN_LOOP_EVENT.js
@@ -30,7 +30,7 @@
  * ```
  *
  * @event Phaser.Tweens.Events#TWEEN_LOOP
- * @type {string}
+ * @type {'loop'}
  * @since 3.19.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.

--- a/src/tweens/events/TWEEN_PAUSE_EVENT.js
+++ b/src/tweens/events/TWEEN_PAUSE_EVENT.js
@@ -24,7 +24,7 @@
  * ```
  *
  * @event Phaser.Tweens.Events#TWEEN_PAUSE
- * @type {string}
+ * @type {'pause'}
  * @since 3.60.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.

--- a/src/tweens/events/TWEEN_REPEAT_EVENT.js
+++ b/src/tweens/events/TWEEN_REPEAT_EVENT.js
@@ -30,7 +30,7 @@
  * ```
  *
  * @event Phaser.Tweens.Events#TWEEN_REPEAT
- * @type {string}
+ * @type {'repeat'}
  * @since 3.19.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.

--- a/src/tweens/events/TWEEN_RESUME_EVENT.js
+++ b/src/tweens/events/TWEEN_RESUME_EVENT.js
@@ -24,7 +24,7 @@
  * ```
  *
  * @event Phaser.Tweens.Events#TWEEN_RESUME
- * @type {string}
+ * @type {'resume'}
  * @since 3.60.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.

--- a/src/tweens/events/TWEEN_START_EVENT.js
+++ b/src/tweens/events/TWEEN_START_EVENT.js
@@ -26,7 +26,7 @@
  * ```
  *
  * @event Phaser.Tweens.Events#TWEEN_START
- * @type {string}
+ * @type {'start'}
  * @since 3.19.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.

--- a/src/tweens/events/TWEEN_STOP_EVENT.js
+++ b/src/tweens/events/TWEEN_STOP_EVENT.js
@@ -22,7 +22,7 @@
  * ```
  *
  * @event Phaser.Tweens.Events#TWEEN_STOP
- * @type {string}
+ * @type {'stop'}
  * @since 3.24.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.

--- a/src/tweens/events/TWEEN_UPDATE_EVENT.js
+++ b/src/tweens/events/TWEEN_UPDATE_EVENT.js
@@ -26,7 +26,7 @@
  * ```
  *
  * @event Phaser.Tweens.Events#TWEEN_UPDATE
- * @type {string}
+ * @type {'update'}
  * @since 3.19.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.

--- a/src/tweens/events/TWEEN_YOYO_EVENT.js
+++ b/src/tweens/events/TWEEN_YOYO_EVENT.js
@@ -31,7 +31,7 @@
  * ```
  *
  * @event Phaser.Tweens.Events#TWEEN_YOYO
- * @type {string}
+ * @type {'yoyo'}
  * @since 3.19.0
  *
  * @param {Phaser.Tweens.Tween} tween - A reference to the Tween instance that emitted the event.


### PR DESCRIPTION
This PR:
[x] Fixes a bug

Describe the changes below:
This PR updates the `@type` annotations of 240-odd `const` declarations in `src` to use the actual runtime variable types instead of `string`.
This allows downstream consumers to have improved autocomplete and manually enforce type safety on `EventEmitter` event names via declaration merging, while also paving the way for something like that to be provided in-house in the future.

Also fixes 1-2 type errors inside the parser code.
<sup>In my defense, the errors in that file were getting on my nerves. 
(Also, I did not know that `"module": "ES5"` was deprecated. What joy!)
</sup>
Fixes #7248

PCRE Regex used:
`@type \{string\}((?:.|\n)+)module\.exports = '(\w*)';$`
=>
`@type {'$2'}$1module.exports = '$2';`

> [!NOTE]
> This _technically_ could break old users' typechecking in fringe scenarios involving functions manually validating their inputs for string literals (or a lack thereof). 
> That being said, this is about as niche as you can get, and any pathological users handling event constants this way is likely not using them for their intended purpose.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation/type-annotation changes; runtime exports remain unchanged, with minimal risk limited to potential tooling/typegen compile impacts.
> 
> **Overview**
> Updates hundreds of event constant files to change JSDoc `@type {string}` annotations into *string-literal types* (e.g. `@type {'animationcomplete'}`), matching the exported runtime event name and improving downstream TypeScript autocomplete/type-safety for `EventEmitter` event names.
> 
> Also tightens `scripts/tsgen/src/Parser.ts` typing in `createTypedef` by explicitly annotating nullable `dom.Type` and typed arrays for properties/intersections, reducing implicit-`any`/null issues during type generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a54a1f379b71e209d76d2d7e5c162628d7fe6d53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->