### PR TITLE
Fix sub-pixel jitter after tile separation

### DIFF
--- a/src/physics/arcade/tilemap/ProcessTileSeparationX.js
+++ b/src/physics/arcade/tilemap/ProcessTileSeparationX.js
@@ -27,6 +27,17 @@ var ProcessTileSeparationX = function (body, x)
     }
 
     body.position.x -= x;
+
+    // Float arithmetic can leave position at e.g. 63.9997, causing 1px
+    // jitter. Snap near-integer results but preserve intentionally
+    // fractional positions (non-integer body sizes from scaled sprites).
+    var rx = Math.round(body.position.x);
+
+    if (Math.abs(body.position.x - rx) < 0.01)
+    {
+        body.position.x = rx;
+    }
+
     body.updateCenter();
 
     if (body.bounce.x === 0)

--- a/src/physics/arcade/tilemap/ProcessTileSeparationY.js
+++ b/src/physics/arcade/tilemap/ProcessTileSeparationY.js
@@ -27,6 +27,17 @@ var ProcessTileSeparationY = function (body, y)
     }
 
     body.position.y -= y;
+
+    // Float arithmetic can leave position at e.g. 63.9997, causing 1px
+    // jitter. Snap near-integer results but preserve intentionally
+    // fractional positions (non-integer body sizes from scaled sprites).
+    var ry = Math.round(body.position.y);
+
+    if (Math.abs(body.position.y - ry) < 0.01)
+    {
+        body.position.y = ry;
+    }
+
     body.updateCenter();
 
     if (body.bounce.y === 0)


### PR DESCRIPTION
This PR:

* Fixes a bug

Describe the changes below:

Fixes #7252

ProcessTileSeparationX/Y can leave body.position at fractional values after subtracting the overlap, like 63.9997 instead of 64.

Tiles are at whole pixel coords so this shouldn't happen, but float math is gonna float math. In pixelArt games it shows up as sprites jittering 1px back and forth while just standing on a tile.

The fix: after the subtraction, if the result is within 0.01 of a whole number, snap it. Catches the float drift without messing up bodies that are supposed to be fractional (scaled sprites with non-integer dimensions, etc).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tile collision resolution; main risk is edge-case behavior changes for bodies that rely on tiny fractional positions near pixel boundaries.
> 
> **Overview**
> Fixes sub-pixel jitter after Arcade Physics tile separation by snapping `body.position.x`/`y` to the nearest integer when the post-separation value is *very close* to a whole pixel.
> 
> The new rounding is tolerance-based (`< 0.01`) so intentionally fractional positions (e.g., from scaled sprites / non-integer body sizes) are preserved, and the rest of the separation/bounce logic remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d01636b1b1e0b8b1713418349dd113457055e995. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->