### PR TITLE
Update `pick`/`weightedPick` typings to accept array-like objects

### DIFF
--- a/src/math/random-data-generator/RandomDataGenerator.js
+++ b/src/math/random-data-generator/RandomDataGenerator.js
@@ -349,10 +349,10 @@ var RandomDataGenerator = new Class({
      * @since 3.0.0
      *
      * @generic T
-     * @genericUse {T[]} - [array]
+     * @genericUse {ArrayLike<T>} - [array]
      * @genericUse {T} - [$return]
      *
-     * @param {T[]} array - The array to pick a random element from.
+     * @param {ArrayLike<T>} array - The array (or array-like object) to pick a random element from.
      *
      * @return {T} A random member of the array.
      */
@@ -368,7 +368,7 @@ var RandomDataGenerator = new Class({
      * @method Phaser.Math.RandomDataGenerator#sign
      * @since 3.0.0
      *
-     * @return {number} -1 or +1.
+     * @return {-1 | 1} -1 or +1.
      */
     sign: function ()
     {
@@ -382,10 +382,10 @@ var RandomDataGenerator = new Class({
      * @since 3.0.0
      *
      * @generic T
-     * @genericUse {T[]} - [array]
+     * @genericUse {ArrayLike<T>} - [array]
      * @genericUse {T} - [$return]
      *
-     * @param {T[]} array - The array to pick a random element from.
+     * @param {ArrayLike<T>} array - The array (or array-like object) to pick a random element from.
      *
      * @return {T} A random member of the array.
      */

--- a/src/math/random-data-generator/RandomDataGenerator.js
+++ b/src/math/random-data-generator/RandomDataGenerator.js
@@ -368,8 +368,10 @@ var RandomDataGenerator = new Class({
      * @method Phaser.Math.RandomDataGenerator#sign
      * @since 3.0.0
      *
-     * @return {-1 | 1} -1 or +1.
+     * @return {number} -1 or +1.
      */
+    // NB: Catharsis (the underlying parser used by JSDoc) does not support parsing negative numbers inside types.
+    // Moreover, the `jsdoc` package used for typegen is (effectively) unmaintained, preventing us from typing this as `-1 | 1`.
     sign: function ()
     {
         return this.pick(this.signs);


### PR DESCRIPTION
Fixes #7257

This PR:
- Fixes a bug

Describe the changes below:

Updated typings of relevant methods to allow passing in array-like objects like `TypedArray` and `readonly` arrays. (At runtime, all we require is a numeric `length` and numeric index support, so array-like objects work just fine here.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> TypeScript declaration changes affect public API typings for `RandomDataGenerator`; while runtime behavior is unchanged, the updated signatures (and the `sign()` typing/doc change) could impact downstream TS compile behavior and type safety.
> 
> **Overview**
> Updates `RandomDataGenerator` `pick` and `weightedPick` to be documented/typed as accepting `ArrayLike<T>` (e.g., typed arrays/readonly arrays) instead of only `T[]`.
> 
> Also adjusts return typing/docs for `sign()` in JS docs (to `-1 | 1`) and in `types/phaser.d.ts` (now `sign(): any` with an updated `@returns`), plus a few minor `@returns` doc formatting tweaks elsewhere in the d.ts file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126152dbd38eb5ccfdd17d7e9b997c7bdc89bbf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->