### PR TITLE
Add missing default export

### DIFF
--- a/src/phaser-esm.js
+++ b/src/phaser-esm.js
@@ -53,3 +53,11 @@ export const LEFT = CONST.LEFT;
 export const RIGHT = CONST.RIGHT;
 export const UP = CONST.UP;
 export const DOWN = CONST.DOWN;
+
+export default {
+    Actions, Animations, BlendModes, Cache, Cameras, Core, Curves, Data,
+    Display, DOM, Events, Filters, Game, GameObjects, Geom, Input, Loader,
+    Math, Physics, Plugins, Renderer, Scale, ScaleModes, Scene, Scenes,
+    Structs, Sound, Textures, Tilemaps, Time, TintModes, Tweens, Utils,
+    VERSION, AUTO, CANVAS, WEBGL, HEADLESS, FOREVER, NONE, LEFT, RIGHT, UP, DOWN
+};


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Add missing default declaration for ESM exports

fixes #7280

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive module-export change; main risk is minor bundler/interop differences for consumers relying on import semantics.
> 
> **Overview**
> Adds a missing `default` export to `src/phaser-esm.js`, exporting a single aggregate object containing the existing named module exports (e.g., `Game`, `Scene`, `Physics`) and constants (e.g., `AUTO`, `WEBGL`).
> 
> This enables `import Phaser from '...'`-style ESM consumption in addition to the existing named exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94865248ac05c88e086d43168330342e6dfb80eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->