### PR TITLE
Fix circular dependency between BatchHandler and the renderer index

### DIFF
--- a/src/renderer/webgl/renderNodes/BatchHandler.js
+++ b/src/renderer/webgl/renderNodes/BatchHandler.js
@@ -8,7 +8,7 @@ var Class = require('../../../utils/Class');
 var ProgramManager = require('../ProgramManager');
 var WebGLVertexBufferLayoutWrapper = require('../wrappers/WebGLVertexBufferLayoutWrapper');
 var RenderNode = require('./RenderNode');
-var Renderer = require('../../../renderer');
+var RendererEvents = require('../../events');
 
 /**
  * @classdesc
@@ -129,7 +129,7 @@ var BatchHandler = new Class({
 
         // Listen for changes to the number of draw calls per batch.
         this.manager.on(
-            Renderer.Events.SET_PARALLEL_TEXTURE_UNITS,
+            RendererEvents.SET_PARALLEL_TEXTURE_UNITS,
             this.updateTextureCount,
             this
         );
@@ -267,7 +267,7 @@ var BatchHandler = new Class({
 
         // Set the dimension-related uniforms and listen for resize events.
         this.resize(renderer.width, renderer.height);
-        renderer.on(Renderer.Events.RESIZE, this.resize, this);
+        renderer.on(RendererEvents.RESIZE, this.resize, this);
     },
 
     /**


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

`BatchHandler` requires the whole renderer index just to read two event names from `Renderer.Events`. Since the renderer index also (indirectly) requires the render nodes, this is a circular dependency, and whether it breaks depends on which side loads first.

The existing builds happen to load the renderer index first, so they are fine. A custom build that loads `core/Game` first reaches `BatchHandler` through `RenderNodeManager` before the index. `BatchHandler` then pulls in the index, which loads `BatchHandlerQuad`, which extends a `BatchHandler` that is still an empty object. The game fails at startup with "TypeError: Object prototype may only be an Object or null: undefined".

Fix: require `renderer/events` directly, as `WebGLRenderer`, `WebGLPipeline` and `RenderTarget` already do. No behaviour change for the existing builds.
